### PR TITLE
feat: add GPT-OSS CLI agent with Strands framework integration

### DIFF
--- a/Strands/README.md
+++ b/Strands/README.md
@@ -1,0 +1,69 @@
+# GPT-OSS CLI Agent
+
+A CLI agent that demonstrates talking to the OpenAI OSS models on Amazon Bedrock using the Strands Agents framework.
+
+## Installation
+
+Install the required dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+### Interactive Mode
+Run without arguments to enter interactive mode:
+```bash
+python gpt-oss-cli.py
+```
+
+### Single Query Mode
+Pass your query as command line arguments:
+```bash
+python gpt-oss-cli.py "What is the weather like today?"
+```
+
+## Configuration
+
+Configure the agent using environment variables:
+
+### Model Configuration
+- `STRANDS_MODEL_ID` - Model to use (default: `openai.gpt-oss-120b-1:0`)
+  - Available models: `openai.gpt-oss-120b-1:0`, `openai.gpt-oss-20b-1:0`
+
+### Generation Parameters
+- `STRANDS_MAX_TOKENS` - Maximum tokens to generate (default: `1000`)
+- `STRANDS_TEMPERATURE` - Temperature for randomness (default: `0.2`)
+- `STRANDS_STREAMING` - Enable streaming responses (default: `false`)
+
+### Reasoning Configuration
+- `STRANDS_SHOW_REASONING` - Show model reasoning process (default: `false`)
+- `STRANDS_REASONING_EFFORT` - Reasoning level (default: `low`)
+  - Available levels: `low`, `medium`, `high`
+
+### System Prompt
+- `STRANDS_SYSTEM_PROMPT` - Custom system prompt (default: rhyming assistant)
+
+## Examples
+
+```bash
+# Use the 20B model with high reasoning
+export STRANDS_MODEL_ID="openai.gpt-oss-20b-1:0"
+export STRANDS_REASONING_EFFORT="high"
+export STRANDS_SHOW_REASONING="true"
+python gpt-oss-cli.py
+
+# Single query with custom temperature
+export STRANDS_TEMPERATURE="0.7"
+python gpt-oss-cli.py "Write a creative story about AI"
+```
+
+## Available Tools
+
+The agent has access to these tools:
+- `current_time` - Get current date and time
+- `file_read` - Read files from the filesystem
+- `file_write` - Write files to the filesystem
+- `http_request` - Make HTTP requests
+- `calculator` - Perform calculations

--- a/Strands/gpt-oss-cli.py
+++ b/Strands/gpt-oss-cli.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+A CLI agent that demonstrates talking to the OpenAI OSS models on Bedrock
+"""
+
+import asyncio
+import os
+import sys
+
+from boto3.session import Config
+from strands import Agent
+from strands.models import BedrockModel
+from strands.telemetry import StrandsTelemetry
+from strands_tools import calculator, current_time, file_read, file_write, http_request
+
+# Initialize telemetry
+StrandsTelemetry().setup_otlp_exporter()
+if os.environ.get("OTEL_CONSOLE"):
+    StrandsTelemetry().setup_console_exporter()
+
+
+async def process_agent_stream(agent: Agent, query: str, show_reasoning: bool = False) -> None:
+    """Process agent stream with prefixed output."""
+    async for event in agent.stream_async(query):
+        if "message" in event and isinstance(event["message"], dict):
+            for item in event["message"].get("content", []):
+                if "reasoningContent" in item and show_reasoning:
+                    text = item["reasoningContent"]["reasoningText"]["text"]
+                    print(f"\n🤔 Reasoning:\n{text}")
+                elif "text" in item and item["text"].strip():
+                    print(f"\n💬 Response:\n{item['text']}")
+                elif "toolUse" in item:
+                    print(f"\n🔧 Tool:\n{item['toolUse']['name']}")
+                elif "toolResult" in item:
+                    content = item["toolResult"].get("content", [{}])[0].get("text", "")
+                    status = item["toolResult"].get("status", "unknown")
+                    print(f"\n⚙️ Result ({status}):\n{content}")
+
+async def interactive_mode(agent: Agent, show_reasoning: bool = False) -> None:
+    """Handle interactive mode."""
+    print("\n🧬 Strands Agents 🧬 - Interactive Mode\nType 'exit' or 'quit' to end.\n")
+    
+    while True:
+        try:
+            query = input("\n> ").strip()
+            if query.lower() in {"exit", "quit", "/quit", "bye"}:
+                print("👋 Goodbye!")
+                break
+            elif query:
+                await process_agent_stream(agent, query, show_reasoning)
+                print("\n")
+        except KeyboardInterrupt:
+            print("\n👋 Goodbye!")
+            break
+
+def main() -> None:
+    """Main entry point."""
+    model_id = os.getenv("STRANDS_MODEL_ID", "openai.gpt-oss-120b-1:0")
+    max_tokens = int(os.getenv("STRANDS_MAX_TOKENS", "1000"))
+    temperature = float(os.getenv("STRANDS_TEMPERATURE", "0.2"))
+    streaming = os.getenv("STRANDS_STREAMING", "false").lower() in ("true", "1", "yes")
+    show_reasoning = os.getenv("STRANDS_SHOW_REASONING", "false").lower() in ("true", "1", "yes")
+    reasoning_effort = os.getenv("STRANDS_REASONING_EFFORT", "low")
+    
+    print("=" * 60)
+    print(f"🤖 Model: {model_id}")
+    print(f"🎛️ Max tokens: {max_tokens}, 🌡️ Temperature: {temperature}, 🌊 Streaming: {streaming}")
+    print(f"🧠 Show reasoning: {show_reasoning}, 💭 Reasoning effort: {reasoning_effort}")
+    print("=" * 60)
+    
+    agent = Agent(
+        model=BedrockModel(
+            model_id=model_id,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            streaming=streaming,
+            additional_request_fields={"reasoning_effort": reasoning_effort},
+            boto_client_config=Config(read_timeout=900, connect_timeout=900, retries={"max_attempts": 3})
+        ),
+        system_prompt=os.getenv("STRANDS_SYSTEM_PROMPT", 
+            "You are a helpful assistant. Reply in rhyme, including Haiku, Syllabic and Alliteration"),
+        tools=[current_time, file_read, file_write, http_request, calculator]
+    )
+    
+    if len(sys.argv) > 1:
+        asyncio.run(process_agent_stream(agent, " ".join(sys.argv[1:]), show_reasoning))
+    else:
+        asyncio.run(interactive_mode(agent, show_reasoning))
+
+if __name__ == "__main__":
+    main()

--- a/Strands/requirements.txt
+++ b/Strands/requirements.txt
@@ -1,0 +1,3 @@
+boto3>=1.40.7
+strands-agents>=1.4.0
+strands-agents-tools>=0.2.3


### PR DESCRIPTION
This PR adds a new CLI agent that demonstrates using OpenAI OSS models on Amazon Bedrock with the Strands Agents framework.

## Features
- Interactive and single query modes
- Support for OpenAI OSS models (120B and 20B variants)
- Configurable reasoning and generation parameters
- Built-in tools: file operations, HTTP requests, calculator
- Environment-based configuration

## Usage
```bash
python gpt-oss-cli.py
python gpt-oss-cli.py "Your query here"
```