### PR TITLE
fix(otel-helper): resilient empty-headers contract + eliminate per-turn latency

### DIFF
--- a/otel-helper/internal/otel/cache.go
+++ b/otel-helper/internal/otel/cache.go
@@ -8,11 +8,14 @@ import (
 	"time"
 )
 
+const currentCacheSchemaVersion = 1
+
 // cacheEntry is the JSON structure of {profile}-otel-headers.json.
 type cacheEntry struct {
-	Headers  map[string]string `json:"headers"`
-	TokenExp int64             `json:"token_exp"`
-	CachedAt int64             `json:"cached_at"`
+	SchemaVersion int               `json:"schema_version"`
+	Headers       map[string]string `json:"headers"`
+	TokenExp      int64             `json:"token_exp"`
+	CachedAt      int64             `json:"cached_at"`
 }
 
 // CacheDir returns the path to ~/.aws-oidc-session/, creating it if needed.
@@ -28,7 +31,9 @@ func CacheDir() (string, error) {
 	return dir, nil
 }
 
-// ReadCachedHeaders returns cached headers if the token hasn't expired (with 10 min buffer).
+// ReadCachedHeaders returns cached headers if the entry is valid.
+// Populated headers are served past expiry (they are static user attributes).
+// Empty-headers entries are served only while their TTL is still valid.
 func ReadCachedHeaders(profile string) (map[string]string, error) {
 	dir, err := CacheDir()
 	if err != nil {
@@ -45,12 +50,46 @@ func ReadCachedHeaders(profile string) (map[string]string, error) {
 		return nil, err
 	}
 
-	now := time.Now().Unix()
-	if entry.TokenExp-now > 600 {
-		return entry.Headers, nil
+	if entry.SchemaVersion < currentCacheSchemaVersion {
+		return nil, fmt.Errorf("cache schema %d < %d; refreshing", entry.SchemaVersion, currentCacheSchemaVersion)
 	}
 
-	return nil, fmt.Errorf("cache expired")
+	if entry.Headers == nil {
+		return nil, fmt.Errorf("cache empty")
+	}
+
+	if len(entry.Headers) == 0 && (entry.TokenExp <= 0 || time.Now().Unix() >= entry.TokenExp) {
+		return nil, fmt.Errorf("empty-headers cache expired or untimed; refreshing")
+	}
+
+	return entry.Headers, nil
+}
+
+// EmptyHeadersWriteSafe returns true only when it is safe to overwrite the
+// cache file for profile with an empty-headers entry. It returns false if a
+// current-schema entry with populated headers already exists, protecting
+// against a transient read failure clobbering valid attribution data.
+func EmptyHeadersWriteSafe(profile string) bool {
+	dir, err := CacheDir()
+	if err != nil {
+		return false
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, profile+"-otel-headers.json"))
+	if err != nil {
+		return os.IsNotExist(err)
+	}
+
+	var entry cacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return false
+	}
+
+	if entry.SchemaVersion < currentCacheSchemaVersion {
+		return true
+	}
+
+	return len(entry.Headers) == 0
 }
 
 // WriteCachedHeaders writes both the metadata cache and the raw headers file atomically.
@@ -62,9 +101,10 @@ func WriteCachedHeaders(profile string, headers map[string]string, tokenExp int6
 
 	// Write main cache file
 	entry := cacheEntry{
-		Headers:  headers,
-		TokenExp: tokenExp,
-		CachedAt: time.Now().Unix(),
+		SchemaVersion: currentCacheSchemaVersion,
+		Headers:       headers,
+		TokenExp:      tokenExp,
+		CachedAt:      time.Now().Unix(),
 	}
 	entryData, err := json.Marshal(entry)
 	if err != nil {

--- a/otel-helper/internal/otel/cache_test.go
+++ b/otel-helper/internal/otel/cache_test.go
@@ -1,6 +1,7 @@
 package otel
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,9 +10,8 @@ import (
 
 func TestWriteAndReadCachedHeaders(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 
 	profile := "test-profile"
 	headers := map[string]string{
@@ -43,31 +43,211 @@ func TestWriteAndReadCachedHeaders(t *testing.T) {
 }
 
 func TestReadCachedHeaders_Expired(t *testing.T) {
+	// Under the new policy, populated headers are served past expiry (they are
+	// static user attributes). The old 10-min buffer no longer applies.
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 
 	profile := "expired-profile"
 	headers := map[string]string{"x-user-email": "test@example.com"}
-	tokenExp := time.Now().Unix() + 300
+	tokenExp := time.Now().Unix() - 1 // already expired
 
 	_ = WriteCachedHeaders(profile, headers, tokenExp)
 
-	_, err := ReadCachedHeaders(profile)
-	if err == nil {
-		t.Error("expected error for expired cache")
+	cached, err := ReadCachedHeaders(profile)
+	if err != nil {
+		t.Errorf("populated headers should be served past expiry, got error: %v", err)
+	}
+	if cached["x-user-email"] != "test@example.com" {
+		t.Errorf("x-user-email = %q, want test@example.com", cached["x-user-email"])
 	}
 }
 
 func TestReadCachedHeaders_Missing(t *testing.T) {
 	tmpDir := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 
 	_, err := ReadCachedHeaders("nonexistent")
 	if err == nil {
 		t.Error("expected error for missing cache")
 	}
 }
+
+func TestReadCachedHeaders_EmptyHeadersMapIsHit(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	profile := "empty-headers-hit"
+	headers := map[string]string{}
+	tokenExp := int64(9999999999)
+
+	if err := WriteCachedHeaders(profile, headers, tokenExp); err != nil {
+		t.Fatalf("WriteCachedHeaders failed: %v", err)
+	}
+
+	cached, err := ReadCachedHeaders(profile)
+	if err != nil {
+		t.Fatalf("expected empty-headers map to be a cache hit, got error: %v", err)
+	}
+	if cached == nil {
+		t.Error("expected non-nil map, got nil")
+	}
+	if len(cached) != 0 {
+		t.Errorf("expected empty map, got %v", cached)
+	}
+}
+
+func TestReadCachedHeaders_ExpiredEmptyHeadersIsMiss(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	profile := "empty-headers-miss"
+	headers := map[string]string{}
+	tokenExp := time.Now().Unix() - 1 // already expired
+
+	if err := WriteCachedHeaders(profile, headers, tokenExp); err != nil {
+		t.Fatalf("WriteCachedHeaders failed: %v", err)
+	}
+
+	_, err := ReadCachedHeaders(profile)
+	if err == nil {
+		t.Error("expected error for expired empty-headers cache")
+	}
+}
+
+func TestReadCachedHeaders_PopulatedHeadersServedPastExpiry(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	profile := "populated-past-expiry"
+	headers := map[string]string{"x-user-email": "real@user.com"}
+	tokenExp := int64(1000) // far in the past
+
+	if err := WriteCachedHeaders(profile, headers, tokenExp); err != nil {
+		t.Fatalf("WriteCachedHeaders failed: %v", err)
+	}
+
+	cached, err := ReadCachedHeaders(profile)
+	if err != nil {
+		t.Fatalf("populated headers must be served past expiry, got error: %v", err)
+	}
+	if cached["x-user-email"] != "real@user.com" {
+		t.Errorf("x-user-email = %q, want real@user.com", cached["x-user-email"])
+	}
+}
+
+func TestWriteTwiceOverwritesCacheFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	profile := "overwrite-test"
+	first := map[string]string{"x-user-email": "first@example.com"}
+	second := map[string]string{"x-user-email": "second@example.com"}
+	tokenExp := int64(9999999999)
+
+	if err := WriteCachedHeaders(profile, first, tokenExp); err != nil {
+		t.Fatalf("first WriteCachedHeaders failed: %v", err)
+	}
+	if err := WriteCachedHeaders(profile, second, tokenExp); err != nil {
+		t.Fatalf("second WriteCachedHeaders failed: %v", err)
+	}
+
+	cached, err := ReadCachedHeaders(profile)
+	if err != nil {
+		t.Fatalf("ReadCachedHeaders failed: %v", err)
+	}
+	if cached["x-user-email"] != "second@example.com" {
+		t.Errorf("second write should win; x-user-email = %q, want second@example.com", cached["x-user-email"])
+	}
+}
+
+func TestReadCachedHeaders_UntimedEmptyHeadersIsMiss(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	profile := "untimed-empty"
+	headers := map[string]string{}
+	tokenExp := int64(0) // untimed
+
+	if err := WriteCachedHeaders(profile, headers, tokenExp); err != nil {
+		t.Fatalf("WriteCachedHeaders failed: %v", err)
+	}
+
+	_, err := ReadCachedHeaders(profile)
+	if err == nil {
+		t.Error("expected error for untimed empty-headers cache")
+	}
+}
+
+func TestEmptyHeadersWriteSafe(t *testing.T) {
+	type tc struct {
+		name     string
+		setup    func(dir string)
+		wantSafe bool
+	}
+	tests := []tc{
+		{
+			name:     "absent file is safe",
+			setup:    func(dir string) {},
+			wantSafe: true,
+		},
+		{
+			name: "populated current-schema is NOT safe",
+			setup: func(dir string) {
+				data := fmt.Sprintf(`{"schema_version":%d,"headers":{"x-user-email":"a@b.com"},"token_exp":9999999999,"cached_at":1}`, currentCacheSchemaVersion)
+				_ = atomicWrite(dir+"/safe-test-otel-headers.json", []byte(data))
+			},
+			wantSafe: false,
+		},
+		{
+			name: "empty current-schema is safe",
+			setup: func(dir string) {
+				data := fmt.Sprintf(`{"schema_version":%d,"headers":{},"token_exp":9999999999,"cached_at":1}`, currentCacheSchemaVersion)
+				_ = atomicWrite(dir+"/safe-test-otel-headers.json", []byte(data))
+			},
+			wantSafe: true,
+		},
+		{
+			name: "stale schema is safe",
+			setup: func(dir string) {
+				data := `{"schema_version":0,"headers":{"x-user-email":"a@b.com"},"token_exp":9999999999,"cached_at":1}`
+				_ = atomicWrite(dir+"/safe-test-otel-headers.json", []byte(data))
+			},
+			wantSafe: true,
+		},
+		{
+			name: "unparseable is NOT safe",
+			setup: func(dir string) {
+				_ = atomicWrite(dir+"/safe-test-otel-headers.json", []byte("not json {{"))
+			},
+			wantSafe: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+			t.Setenv("USERPROFILE", tmpDir)
+
+			cacheDir := tmpDir + "/.aws-oidc-session"
+			if err := os.MkdirAll(cacheDir, 0700); err != nil {
+				t.Fatalf("mkdir failed: %v", err)
+			}
+			tt.setup(cacheDir)
+
+			got := EmptyHeadersWriteSafe("safe-test")
+			if got != tt.wantSafe {
+				t.Errorf("EmptyHeadersWriteSafe = %v, want %v", got, tt.wantSafe)
+			}
+		})
+	}
+}
+

--- a/otel-helper/main.go
+++ b/otel-helper/main.go
@@ -10,11 +10,16 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"otel-helper/internal/jwt"
 	"otel-helper/internal/otel"
 	"otel-helper/internal/version"
 )
+
+// emptyHeadersCacheTTLSeconds bounds how long THIS binary serves an empty-headers
+// result from the file cache before it retries credential-process.
+const emptyHeadersCacheTTLSeconds = 120
 
 var (
 	logger  = log.New(os.Stderr, "", log.LstdFlags)
@@ -70,16 +75,16 @@ func run(testMode bool) int {
 		var err error
 		token, err = getTokenViaCredentialProcess(profile)
 		if err != nil || token == "" {
-			debugPrint("Could not obtain authentication token")
-			return 1
+			debugPrint("Could not obtain authentication token; emitting empty headers")
+			return emitEmptyHeaders(profile, testMode)
 		}
 	}
 
 	// Decode JWT and extract user info
 	claims, err := jwt.DecodePayload(token)
 	if err != nil {
-		debugPrint("Error decoding JWT: %v", err)
-		return 1
+		debugPrint("Error decoding JWT: %v; emitting empty headers", err)
+		return emitEmptyHeaders(profile, testMode)
 	}
 
 	userInfo := otel.ExtractUserInfo(claims)
@@ -100,6 +105,23 @@ func run(testMode bool) int {
 		outputJSON(headers)
 	}
 
+	return 0
+}
+
+func emitEmptyHeaders(profile string, testMode bool) int {
+	headers := map[string]string{}
+	if testMode {
+		printTestOutput(otel.UserInfo{}, headers)
+		return 0
+	}
+	if otel.EmptyHeadersWriteSafe(profile) {
+		if err := otel.WriteCachedHeaders(profile, headers, time.Now().Unix()+emptyHeadersCacheTTLSeconds); err != nil {
+			debugPrint("Failed to write empty-headers cache: %v", err)
+		}
+	} else {
+		debugPrint("Skipping empty-headers cache write to preserve existing attribution")
+	}
+	outputJSON(headers)
 	return 0
 }
 

--- a/otel-helper/main_test.go
+++ b/otel-helper/main_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRun_NoToken_EmitsEmptyHeadersAndExitsZero(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("AWS_PROFILE", "default")
+	t.Setenv("AWS_OIDC_AUTH_MONITORING_TOKEN", "")
+
+	code := run(false)
+	if code != 0 {
+		t.Fatalf("run() = %d, want 0", code)
+	}
+
+	cacheFile := filepath.Join(tmpDir, ".aws-oidc-session", "default-otel-headers.json")
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		t.Fatalf("cache file missing: %v", err)
+	}
+
+	var entry struct {
+		Headers  map[string]string `json:"headers"`
+		TokenExp int64             `json:"token_exp"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("invalid JSON in cache: %v", err)
+	}
+	if entry.Headers == nil {
+		t.Error("headers should be non-nil empty map, got nil")
+	}
+	if len(entry.Headers) != 0 {
+		t.Errorf("headers should be empty map, got %v", entry.Headers)
+	}
+	if entry.TokenExp <= 0 {
+		t.Errorf("token_exp should be > 0, got %d", entry.TokenExp)
+	}
+}
+
+func TestRun_TestMode_NoToken_DoesNotWriteCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("AWS_PROFILE", "default")
+	t.Setenv("AWS_OIDC_AUTH_MONITORING_TOKEN", "")
+
+	code := run(true)
+	if code != 0 {
+		t.Fatalf("run(testMode=true) = %d, want 0", code)
+	}
+
+	cacheFile := filepath.Join(tmpDir, ".aws-oidc-session", "default-otel-headers.json")
+	if _, err := os.Stat(cacheFile); !os.IsNotExist(err) {
+		t.Error("cache file should NOT exist in test mode")
+	}
+}
+
+func TestRun_FreshEmptyCache_ServedViaLayer1(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("AWS_PROFILE", "default")
+	t.Setenv("AWS_OIDC_AUTH_MONITORING_TOKEN", "")
+
+	cacheDir := filepath.Join(tmpDir, ".aws-oidc-session")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cacheFile := filepath.Join(cacheDir, "default-otel-headers.json")
+	seedData := []byte(`{"schema_version":1,"headers":{},"token_exp":9999999999,"cached_at":1000}`)
+	if err := os.WriteFile(cacheFile, seedData, 0600); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	code := run(false)
+	if code != 0 {
+		t.Fatalf("run() = %d, want 0", code)
+	}
+
+	after, err := os.ReadFile(cacheFile)
+	if err != nil {
+		t.Fatalf("reading cache after run: %v", err)
+	}
+	if string(after) != string(seedData) {
+		t.Errorf("cache was rewritten; want identical bytes\ngot:  %s\nwant: %s", after, seedData)
+	}
+}
+
+func TestRun_PopulatedExpiredEntry_ServedNotRewritten(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("AWS_PROFILE", "default")
+	t.Setenv("AWS_OIDC_AUTH_MONITORING_TOKEN", "")
+
+	cacheDir := filepath.Join(tmpDir, ".aws-oidc-session")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cacheFile := filepath.Join(cacheDir, "default-otel-headers.json")
+	seedData := []byte(`{"schema_version":1,"headers":{"x-user-email":"real@user.com"},"token_exp":1000,"cached_at":500}`)
+	if err := os.WriteFile(cacheFile, seedData, 0600); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	code := run(false)
+	if code != 0 {
+		t.Fatalf("run() = %d, want 0", code)
+	}
+
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		t.Fatalf("reading cache after run: %v", err)
+	}
+	var entry struct {
+		Headers map[string]string `json:"headers"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if entry.Headers["x-user-email"] != "real@user.com" {
+		t.Errorf("x-user-email = %q, want real@user.com (entry should not be clobbered)", entry.Headers["x-user-email"])
+	}
+}


### PR DESCRIPTION
## Summary

- **Contract fix**: when no monitoring token is available (fresh install, post-expiry, CI host) or the JWT fails to decode, the helper previously exited non-zero with empty stdout — causing Claude Code to log `otelHeadersHelper did not return a valid value` and drop the telemetry batch on every export cycle. Both failure paths now call `emitEmptyHeaders()`, which prints `{}` and exits 0 so export continues unattributed.
- **Per-turn latency**: empty-headers result is cached with a 120s TTL so credential-process is not re-spawned on every export cycle while unauthenticated. Populated entries are served past token expiry (they are static user attributes).
- **Safety guards**: `EmptyHeadersWriteSafe` prevents a transient Layer-1 read failure from clobbering a valid populated entry with `{}`; `schema_version` field added to `cacheEntry` to support stale-schema detection.

No fabricated identity is ever emitted — unattributed (`{}`) until the user authenticates, at which point real per-user attribution resumes on the next helper invocation.

Port of [aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock#441](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/pull/441), adapted to local conventions (`~/.aws-oidc-session`, `AWS_OIDC_AUTH_MONITORING_TOKEN`, module `otel-helper`).

## Test plan

- [ ] `go vet ./...` — clean
- [ ] `go test ./...` — 26/26 tests pass across all packages
- [ ] Binary verified at surface against all 4 contract scenarios:
  - No-token → `{}` + exit 0 + cache written with positive TTL (~120s)
  - Warm empty-headers cache → Layer 1 hit, file byte-identical (no credential-process spawn)
  - Populated expired entry → served on stdout, not clobbered by no-token run
  - `--test` flag → exit 0, no cache file written
- [ ] Probes: malformed JWT → `{}` + exit 0; expired empty-headers cache → treated as miss, fresh TTL written on retry