### PR TITLE
feat(aws-oidc-auth): add credential-process entry point

### DIFF
--- a/aws-oidc-auth/.gitignore
+++ b/aws-oidc-auth/.gitignore
@@ -1,5 +1,5 @@
 bin/
-credential-process
-credential-process.exe
-otel-helper
-otel-helper.exe
+/credential-process
+/credential-process.exe
+/otel-helper
+/otel-helper.exe

--- a/aws-oidc-auth/cmd/credential-process/main.go
+++ b/aws-oidc-auth/cmd/credential-process/main.go
@@ -1,0 +1,375 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+
+	"aws-oidc-auth/internal/azure"
+	"aws-oidc-auth/internal/config"
+	"aws-oidc-auth/internal/federation"
+	"aws-oidc-auth/internal/oidc"
+	"aws-oidc-auth/internal/portlock"
+	"aws-oidc-auth/internal/provider"
+	"aws-oidc-auth/internal/sso"
+	"aws-oidc-auth/internal/storage"
+	"aws-oidc-auth/internal/version"
+)
+
+const (
+	defaultRedirectPort  = 5115
+	credExpiryBufferSecs = 300 // refresh 5 min before actual expiry
+)
+
+var debugMode = os.Getenv("AWS_OIDC_AUTH_DEBUG") == "1"
+
+func debugf(format string, args ...interface{}) {
+	if debugMode {
+		fmt.Fprintf(os.Stderr, "[debug] "+format+"\n", args...)
+	}
+}
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	profileFlag := flag.String("profile", "", "config.json profile name (auto-detected if only one profile)")
+	versionFlag := flag.Bool("version", false, "print version and exit")
+	checkExpirationFlag := flag.Bool("check-expiration", false, "print credential expiration status and exit")
+	refreshIfNeededFlag := flag.Bool("refresh-if-needed", false, "refresh credentials only if expired or near expiry")
+	clearCacheFlag := flag.Bool("clear-cache", false, "clear cached credentials and force re-authentication")
+	setClientSecretFlag := flag.Bool("set-client-secret", false, "store Azure AD client secret in OS keyring")
+	flag.Parse()
+
+	if *versionFlag {
+		fmt.Fprintf(os.Stderr, "aws-oidc-auth credential-process %s\n", version.Version)
+		return 0
+	}
+
+	profileName := *profileFlag
+	if profileName == "" {
+		profileName = os.Getenv("AWS_OIDC_AUTH_PROFILE")
+	}
+	if profileName == "" {
+		profileName = os.Getenv("AWS_PROFILE")
+	}
+	if profileName == "" {
+		profileName = config.AutoDetectProfile()
+	}
+	if profileName == "" {
+		fmt.Fprintln(os.Stderr, "error: profile name required (use --profile, AWS_OIDC_AUTH_PROFILE, or AWS_PROFILE, or have exactly one profile in config.json)")
+		return 1
+	}
+
+	cfg, err := config.LoadProfile(profileName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error loading profile %q: %v\n", profileName, err)
+		return 1
+	}
+
+	// Inject Azure client secret from env or keyring into config
+	if cfg.ProviderType == "azure" || cfg.AzureAuthMode != "" {
+		if envSecret := os.Getenv("AWS_OIDC_AUTH_CLIENT_SECRET"); envSecret != "" {
+			cfg.ClientSecret = envSecret
+		} else if cfg.AzureAuthMode == "" || cfg.AzureAuthMode == "secret" {
+			if secret, err := azure.ReadClientSecret(profileName); err == nil && secret != "" {
+				cfg.ClientSecret = secret
+			}
+		}
+	}
+
+	// Auto-detect provider type
+	if cfg.ProviderType == "auto" {
+		cfg.ProviderType = provider.Detect(cfg.ProviderDomain)
+		if !provider.IsKnown(cfg.ProviderType) {
+			cfg.ProviderType = "oidc"
+		}
+	}
+	debugf("profile=%s federation=%s provider=%s storage=%s", profileName, cfg.FederationType, cfg.ProviderType, cfg.CredentialStorage)
+
+	// Utility flags
+	if *setClientSecretFlag {
+		return runSetClientSecret(profileName)
+	}
+	if *clearCacheFlag {
+		return runClearCache(profileName, cfg.CredentialStorage)
+	}
+	if *checkExpirationFlag {
+		return runCheckExpiration(profileName, cfg.CredentialStorage)
+	}
+	if *refreshIfNeededFlag {
+		return runRefreshIfNeeded(profileName, cfg)
+	}
+
+	// Normal credential_process flow
+	return runCredentialProcess(profileName, cfg)
+}
+
+func runCredentialProcess(profile string, cfg *config.ProfileConfig) int {
+	// Try cached credentials first
+	creds, err := readCachedCredentials(profile, cfg.CredentialStorage)
+	if err == nil && creds != nil && !storage.IsExpiredDummy(creds) {
+		remaining := storage.ParseExpirationSeconds(creds.Expiration)
+		debugf("cached credentials found, %.0fs remaining", remaining)
+		if remaining > float64(credExpiryBufferSecs) {
+			return outputCredentials(creds)
+		}
+		debugf("credentials expiring soon, refreshing")
+	}
+
+	return authenticate(profile, cfg)
+}
+
+func runRefreshIfNeeded(profile string, cfg *config.ProfileConfig) int {
+	creds, err := readCachedCredentials(profile, cfg.CredentialStorage)
+	if err == nil && creds != nil && !storage.IsExpiredDummy(creds) {
+		remaining := storage.ParseExpirationSeconds(creds.Expiration)
+		if remaining > float64(credExpiryBufferSecs) {
+			debugf("credentials still valid (%.0fs remaining), no refresh needed", remaining)
+			return 0
+		}
+	}
+	return authenticate(profile, cfg)
+}
+
+func runCheckExpiration(profile string, credentialStorage string) int {
+	creds, err := readCachedCredentials(profile, credentialStorage)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "no cached credentials: %v\n", err)
+		return 1
+	}
+	if creds == nil || storage.IsExpiredDummy(creds) {
+		fmt.Fprintln(os.Stderr, "no valid credentials cached")
+		return 1
+	}
+	remaining := storage.ParseExpirationSeconds(creds.Expiration)
+	if remaining <= 0 {
+		fmt.Fprintf(os.Stderr, "credentials expired\n")
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "credentials valid, expires in %.0f seconds (%s)\n", remaining, creds.Expiration)
+	return 0
+}
+
+func runClearCache(profile string, credentialStorage string) int {
+	if credentialStorage == "keyring" {
+		if err := storage.ClearKeyring(profile); err != nil {
+			fmt.Fprintf(os.Stderr, "error clearing keyring: %v\n", err)
+			return 1
+		}
+	} else {
+		expired := &federation.AWSCredentials{
+			Version:         1,
+			AccessKeyID:     "EXPIRED",
+			SecretAccessKey: "EXPIRED",
+			SessionToken:    "EXPIRED",
+			Expiration:      "2000-01-01T00:00:00Z",
+		}
+		if err := storage.SaveToCredentialsFile(expired, profile); err != nil {
+			fmt.Fprintf(os.Stderr, "error clearing session file: %v\n", err)
+			return 1
+		}
+	}
+	fmt.Fprintln(os.Stderr, "credentials cleared")
+	return 0
+}
+
+func runSetClientSecret(profile string) int {
+	fmt.Fprint(os.Stderr, "Enter Azure AD client secret: ")
+	var secret string
+	var err error
+
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		var b []byte
+		b, err = term.ReadPassword(int(os.Stdin.Fd()))
+		secret = string(b)
+		fmt.Fprintln(os.Stderr) // newline after hidden input
+	} else {
+		scanner := bufio.NewScanner(os.Stdin)
+		if scanner.Scan() {
+			secret = strings.TrimRight(scanner.Text(), "\r\n")
+		}
+		err = scanner.Err()
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading secret: %v\n", err)
+		return 1
+	}
+	if secret == "" {
+		fmt.Fprintln(os.Stderr, "error: secret cannot be empty")
+		return 1
+	}
+
+	if err := azure.SaveClientSecret(profile, secret); err != nil {
+		fmt.Fprintf(os.Stderr, "error saving secret: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(os.Stderr, "client secret saved to keyring")
+	return 0
+}
+
+func authenticate(profile string, cfg *config.ProfileConfig) int {
+	switch cfg.FederationType {
+	case "sso":
+		return runSSO(profile, cfg)
+	default:
+		return runOIDC(profile, cfg)
+	}
+}
+
+// runSSO handles AWS IAM Identity Center (SSO) federation.
+func runSSO(profile string, cfg *config.ProfileConfig) int {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	cachedToken, err := sso.ReadCachedToken(cfg.SSOStartURL)
+	if err != nil || !sso.IsTokenValid(cachedToken) {
+		debugf("SSO token missing or expired, starting device auth flow")
+		cachedToken, err = sso.RunDeviceAuthFlow(ctx, cfg.SSOStartURL, cfg.SSORegion)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "SSO login failed: %v\n", err)
+			return 1
+		}
+	} else {
+		debugf("using cached SSO token")
+	}
+
+	creds, err := sso.GetRoleCredentials(ctx, cfg.SSORegion, cachedToken.AccessToken, cfg.SSOAccountID, cfg.SSORoleName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "getting SSO role credentials: %v\n", err)
+		return 1
+	}
+
+	if err := saveCachedCredentials(creds, profile, cfg.CredentialStorage); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to cache credentials: %v\n", err)
+	}
+
+	return outputCredentials(creds)
+}
+
+// runOIDC handles OIDC-based federation (direct STS or Cognito).
+func runOIDC(profile string, cfg *config.ProfileConfig) int {
+	// Acquire redirect port — wait if another instance is mid-auth
+	ln, err := portlock.TryAcquire(defaultRedirectPort)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error acquiring port %d: %v\n", defaultRedirectPort, err)
+		return 1
+	}
+	if ln == nil {
+		debugf("port %d busy, waiting for it to free", defaultRedirectPort)
+		if !portlock.WaitForRelease(defaultRedirectPort, 30*time.Second) {
+			fmt.Fprintf(os.Stderr, "timeout waiting for port %d to become available\n", defaultRedirectPort)
+			return 1
+		}
+	} else {
+		ln.Close()
+	}
+
+	// Build auth options
+	authOpts := &oidc.AuthOptions{
+		ProviderDomain: cfg.ProviderDomain,
+		ClientID:       cfg.ClientID,
+		ProviderType:   cfg.ProviderType,
+		RedirectPort:   defaultRedirectPort,
+	}
+
+	// Confidential client: Azure
+	if cfg.ProviderType == "azure" {
+		switch cfg.AzureAuthMode {
+		case "certificate":
+			tokenURL := "https://" + cfg.ProviderDomain + "/oauth2/v2.0/token"
+			assertion, err := azure.BuildClientAssertion(
+				cfg.ClientCertificatePath,
+				cfg.ClientCertificateKeyPath,
+				cfg.ClientID,
+				tokenURL,
+			)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "building client assertion: %v\n", err)
+				return 1
+			}
+			authOpts.ConfidentialClient = &oidc.ConfidentialClientOpts{
+				ClientAssertion:     assertion,
+				ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+			}
+		case "secret":
+			if cfg.ClientSecret == "" {
+				fmt.Fprintln(os.Stderr, "error: azure_auth_mode=secret but no client secret found; run with --set-client-secret or set AWS_OIDC_AUTH_CLIENT_SECRET")
+				return 1
+			}
+			authOpts.ConfidentialClient = &oidc.ConfidentialClientOpts{
+				ClientSecret: cfg.ClientSecret,
+			}
+		}
+	}
+
+	result, err := oidc.AuthenticateWithOpts(authOpts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "authentication failed: %v\n", err)
+		return 1
+	}
+	debugf("OIDC authentication successful")
+
+	// Save monitoring token for otel-helper
+	if err := storage.SaveMonitoringToken(profile, cfg.CredentialStorage, result.IDToken, result.TokenClaims); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to save monitoring token: %v\n", err)
+	}
+
+	// Exchange OIDC token for AWS credentials
+	var creds *federation.AWSCredentials
+	switch cfg.FederationType {
+	case "direct":
+		creds, err = federation.AssumeRoleWithWebIdentity(
+			cfg.AWSRegion, cfg.FederatedRoleARN, result.IDToken,
+			result.TokenClaims, cfg.MaxSessionDuration,
+		)
+	default: // "cognito"
+		creds, err = federation.GetCredentialsViaCognito(
+			cfg.AWSRegion, cfg.IdentityPoolID, cfg.ProviderDomain,
+			cfg.ProviderType, result.IDToken, result.TokenClaims,
+		)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "credential exchange failed: %v\n", err)
+		return 1
+	}
+	debugf("credential exchange successful, expires %s", creds.Expiration)
+
+	if err := saveCachedCredentials(creds, profile, cfg.CredentialStorage); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to cache credentials: %v\n", err)
+	}
+
+	return outputCredentials(creds)
+}
+
+func readCachedCredentials(profile, storageType string) (*federation.AWSCredentials, error) {
+	if storageType == "keyring" {
+		return storage.ReadFromKeyring(profile)
+	}
+	return storage.ReadFromCredentialsFile(profile)
+}
+
+func saveCachedCredentials(creds *federation.AWSCredentials, profile, storageType string) error {
+	if storageType == "keyring" {
+		return storage.SaveToKeyring(creds, profile)
+	}
+	return storage.SaveToCredentialsFile(creds, profile)
+}
+
+func outputCredentials(creds *federation.AWSCredentials) int {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(creds); err != nil {
+		fmt.Fprintf(os.Stderr, "error encoding credentials: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/otel-helper/.gitignore
+++ b/otel-helper/.gitignore
@@ -1,1 +1,3 @@
 bin/
+/otel-helper
+/otel-helper.exe


### PR DESCRIPTION
## Summary

- Creates `aws-oidc-auth/cmd/credential-process/main.go` — the binary entry point that the Makefile has always targeted but was missing, making the module unbuildable
- Wires existing internal packages (`config`, `oidc`, `sso`, `federation`, `storage`, `azure`, `portlock`, `provider`, `version`) into the complete `credential_process` flow
- Fixes `aws-oidc-auth/.gitignore` to anchor binary rules with `/` so the `cmd/credential-process/` directory is no longer accidentally ignored
- Fixes `otel-helper/.gitignore` to ignore the root test binary

## What it supports

**Auth flows:**
- SSO/Identity Center: cached token → device auth → `GetRoleCredentials`
- OIDC + direct STS: PKCE auth code → `AssumeRoleWithWebIdentity`
- OIDC + Cognito: PKCE auth code → Cognito Identity Pool

**Flags:** `--profile`, `--version`, `--check-expiration`, `--refresh-if-needed`, `--clear-cache`, `--set-client-secret`

**Env vars:** `AWS_OIDC_AUTH_PROFILE`, `AWS_OIDC_AUTH_DEBUG`, `AWS_OIDC_AUTH_CLIENT_SECRET`, `AWS_PROFILE`

## Test plan

- [x] `go build ./cmd/credential-process/` succeeds
- [x] `--version` prints version string
- [x] Valid cached credentials served directly (no re-auth)
- [x] `--check-expiration` reports expiry correctly for valid and expired creds
- [x] `--refresh-if-needed` returns 0 without re-authing when creds are still valid
- [x] `--clear-cache` writes EXPIRED placeholder; subsequent `--check-expiration` returns 1
- [x] Auto-detect profile works when config has exactly one profile
- [x] `AWS_OIDC_AUTH_DEBUG=1` emits debug lines to stderr
- [x] Clean error messages for missing config, ambiguous profile, missing `--profile`