### PR TITLE
test: add code coverage for aws-oidc-auth, otel-helper, and jwt-middleware

### DIFF
--- a/aws-oidc-auth/.gitignore
+++ b/aws-oidc-auth/.gitignore
@@ -3,3 +3,5 @@ bin/
 /credential-process.exe
 /otel-helper
 /otel-helper.exe
+coverage.out
+coverage.html

--- a/aws-oidc-auth/Makefile
+++ b/aws-oidc-auth/Makefile
@@ -2,12 +2,17 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 LDFLAGS := -s -w -X aws-oidc-auth/internal/version.Version=$(VERSION)
 OUT ?= bin
 
-.PHONY: all test clean fmt vet macos-arm64 macos-intel linux-x64 linux-arm64 windows
+.PHONY: all test coverage clean fmt vet macos-arm64 macos-intel linux-x64 linux-arm64 windows
 
 all: macos-arm64 macos-intel linux-x64 linux-arm64 windows
 
 test:
 	go test ./... -v
+
+coverage:
+	go test ./... -coverprofile=coverage.out -covermode=atomic
+	go tool cover -func=coverage.out
+	go tool cover -html=coverage.out -o coverage.html
 
 fmt:
 	go fmt ./...

--- a/aws-oidc-auth/cmd/credential-process/main_test.go
+++ b/aws-oidc-auth/cmd/credential-process/main_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"aws-oidc-auth/internal/federation"
+	"aws-oidc-auth/internal/storage"
+)
+
+// resetFlags resets the global flag.CommandLine between test calls to run(),
+// which registers flags on each invocation.
+func resetFlags() {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+}
+
+func setupConfig(t *testing.T, tmp, content string) {
+	t.Helper()
+	dir := filepath.Join(tmp, "aws-oidc-auth")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeCreds(t *testing.T, tmp, profile, expiration string) {
+	t.Helper()
+	dir := filepath.Join(tmp, ".aws")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	content := "[" + profile + "]\n" +
+		"aws_access_key_id = AKIDTEST\n" +
+		"aws_secret_access_key = SECRETTEST\n" +
+		"aws_session_token = TOKENTEST\n" +
+		"x-expiration = " + expiration + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "credentials"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const basicConfig = `{
+	"profiles": {
+		"default": {
+			"provider_domain": "dev-123.okta.com",
+			"client_id": "test",
+			"aws_region": "us-east-1",
+			"credential_storage": "session",
+			"federation_type": "cognito",
+			"identity_pool_id": "us-east-1:pool"
+		}
+	}
+}`
+
+func TestRun_CheckExpiration_Valid(t *testing.T) {
+	resetFlags()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_OIDC_AUTH_PROFILE", "")
+
+	setupConfig(t, tmp, basicConfig)
+	future := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	writeCreds(t, tmp, "default", future)
+
+	os.Args = []string{"credential-process", "--profile", "default", "--check-expiration"}
+	if code := run(); code != 0 {
+		t.Errorf("expected exit 0, got %d", code)
+	}
+}
+
+func TestRun_CheckExpiration_Expired(t *testing.T) {
+	resetFlags()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_OIDC_AUTH_PROFILE", "")
+
+	setupConfig(t, tmp, basicConfig)
+	writeCreds(t, tmp, "default", "2000-01-01T00:00:00Z")
+
+	os.Args = []string{"credential-process", "--profile", "default", "--check-expiration"}
+	if code := run(); code != 1 {
+		t.Errorf("expected exit 1 for expired creds, got %d", code)
+	}
+}
+
+func TestRun_CheckExpiration_NoCredentials(t *testing.T) {
+	resetFlags()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_OIDC_AUTH_PROFILE", "")
+
+	setupConfig(t, tmp, basicConfig)
+
+	os.Args = []string{"credential-process", "--profile", "default", "--check-expiration"}
+	if code := run(); code != 1 {
+		t.Errorf("expected exit 1 for missing creds, got %d", code)
+	}
+}
+
+func TestRun_ClearCache(t *testing.T) {
+	resetFlags()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_OIDC_AUTH_PROFILE", "")
+
+	setupConfig(t, tmp, basicConfig)
+	future := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	writeCreds(t, tmp, "default", future)
+
+	os.Args = []string{"credential-process", "--profile", "default", "--clear-cache"}
+	if code := run(); code != 0 {
+		t.Errorf("expected exit 0, got %d", code)
+	}
+
+	creds, err := storage.ReadFromCredentialsFile("default")
+	if err != nil {
+		t.Fatalf("read after clear: %v", err)
+	}
+	if !storage.IsExpiredDummy(creds) {
+		t.Errorf("expected EXPIRED placeholder, got %+v", creds)
+	}
+}
+
+func TestRun_RefreshIfNeeded_StillValid(t *testing.T) {
+	resetFlags()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_OIDC_AUTH_PROFILE", "")
+
+	setupConfig(t, tmp, basicConfig)
+	future := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	writeCreds(t, tmp, "default", future)
+
+	os.Args = []string{"credential-process", "--profile", "default", "--refresh-if-needed"}
+	if code := run(); code != 0 {
+		t.Errorf("expected exit 0 (no refresh needed), got %d", code)
+	}
+}
+
+func TestRun_NormalMode_ServesFromCache(t *testing.T) {
+	resetFlags()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_OIDC_AUTH_PROFILE", "")
+
+	setupConfig(t, tmp, basicConfig)
+	future := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	writeCreds(t, tmp, "default", future)
+
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+
+	os.Args = []string{"credential-process", "--profile", "default"}
+	code := run()
+
+	w.Close()
+	os.Stdout = old
+
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d", code)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	var creds federation.AWSCredentials
+	if err := json.Unmarshal(buf[:n], &creds); err != nil {
+		t.Fatalf("output not valid JSON: %v\nraw: %s", err, buf[:n])
+	}
+	if creds.AccessKeyID != "AKIDTEST" {
+		t.Errorf("AccessKeyID: got %q", creds.AccessKeyID)
+	}
+}
+
+func TestRun_Version(t *testing.T) {
+	resetFlags()
+	os.Args = []string{"credential-process", "--version"}
+	if code := run(); code != 0 {
+		t.Errorf("expected exit 0 for --version, got %d", code)
+	}
+}
+
+func TestRun_MissingProfile(t *testing.T) {
+	resetFlags()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_OIDC_AUTH_PROFILE", "")
+
+	setupConfig(t, tmp, `{"profiles":{"a":{},"b":{}}}`)
+
+	os.Args = []string{"credential-process"}
+	if code := run(); code != 1 {
+		t.Errorf("expected exit 1 for missing profile, got %d", code)
+	}
+}
+
+func TestRun_ProfileFromEnv(t *testing.T) {
+	resetFlags()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_OIDC_AUTH_PROFILE", "envprofile")
+	t.Setenv("AWS_PROFILE", "")
+
+	setupConfig(t, tmp, `{"profiles":{
+		"envprofile": {
+			"credential_storage": "session",
+			"federation_type": "cognito",
+			"aws_region": "us-east-1",
+			"identity_pool_id": "us-east-1:pool"
+		}
+	}}`)
+	future := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	writeCreds(t, tmp, "envprofile", future)
+
+	os.Args = []string{"credential-process", "--check-expiration"}
+	if code := run(); code != 0 {
+		t.Errorf("expected exit 0, got %d", code)
+	}
+}
+
+func TestRun_MissingConfigFile(t *testing.T) {
+	resetFlags()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_OIDC_AUTH_PROFILE", "")
+
+	os.Args = []string{"credential-process", "--profile", "default", "--check-expiration"}
+	if code := run(); code != 1 {
+		t.Errorf("expected exit 1 for missing config, got %d", code)
+	}
+}

--- a/aws-oidc-auth/internal/config/config_test.go
+++ b/aws-oidc-auth/internal/config/config_test.go
@@ -1,0 +1,267 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeConfig(t *testing.T, dir, content string) {
+	t.Helper()
+	p := filepath.Join(dir, "aws-oidc-auth", "config.json")
+	if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadProfile_NewFormat(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	writeConfig(t, tmp, `{
+		"profiles": {
+			"default": {
+				"provider_domain": "dev-123.okta.com",
+				"client_id": "abc",
+				"aws_region": "us-west-2",
+				"credential_storage": "session",
+				"federation_type": "cognito",
+				"identity_pool_id": "us-west-2:pool-id"
+			}
+		}
+	}`)
+
+	p, err := LoadProfile("default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.ProviderDomain != "dev-123.okta.com" {
+		t.Errorf("got ProviderDomain=%q", p.ProviderDomain)
+	}
+	if p.AWSRegion != "us-west-2" {
+		t.Errorf("got AWSRegion=%q", p.AWSRegion)
+	}
+	if p.CredentialStorage != "session" {
+		t.Errorf("got CredentialStorage=%q", p.CredentialStorage)
+	}
+}
+
+func TestLoadProfile_OldFormat(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	writeConfig(t, tmp, `{
+		"myprofile": {
+			"provider_domain": "login.microsoftonline.com/tenant/v2.0",
+			"client_id": "xyz",
+			"federation_type": "direct",
+			"federated_role_arn": "arn:aws:iam::123:role/R"
+		}
+	}`)
+
+	p, err := LoadProfile("myprofile")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.FederationType != "direct" {
+		t.Errorf("got FederationType=%q", p.FederationType)
+	}
+	if p.MaxSessionDuration != 43200 {
+		t.Errorf("direct default MaxSessionDuration: got %d", p.MaxSessionDuration)
+	}
+}
+
+func TestLoadProfile_LegacyOktaFields(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	writeConfig(t, tmp, `{
+		"profiles": {
+			"legacy": {
+				"okta_domain": "company.okta.com",
+				"okta_client_id": "old-client"
+			}
+		}
+	}`)
+
+	p, err := LoadProfile("legacy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.ProviderDomain != "company.okta.com" {
+		t.Errorf("legacy okta_domain not mapped: got %q", p.ProviderDomain)
+	}
+	if p.ClientID != "old-client" {
+		t.Errorf("legacy okta_client_id not mapped: got %q", p.ClientID)
+	}
+}
+
+func TestLoadProfile_IdentityPoolNameMapped(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	writeConfig(t, tmp, `{
+		"profiles": {
+			"p": {
+				"identity_pool_name": "us-east-1:pool"
+			}
+		}
+	}`)
+
+	p, err := LoadProfile("p")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.IdentityPoolID != "us-east-1:pool" {
+		t.Errorf("identity_pool_name not promoted: got %q", p.IdentityPoolID)
+	}
+}
+
+func TestLoadProfile_Defaults(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	writeConfig(t, tmp, `{"profiles": {"p": {}}}`)
+
+	p, err := LoadProfile("p")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.AWSRegion != "us-east-1" {
+		t.Errorf("default region: got %q", p.AWSRegion)
+	}
+	if p.ProviderType != "auto" {
+		t.Errorf("default provider_type: got %q", p.ProviderType)
+	}
+	if p.CredentialStorage != "session" {
+		t.Errorf("default credential_storage: got %q", p.CredentialStorage)
+	}
+	if p.FederationType != "cognito" {
+		t.Errorf("default federation_type: got %q", p.FederationType)
+	}
+	if p.MaxSessionDuration != 28800 {
+		t.Errorf("default MaxSessionDuration: got %d", p.MaxSessionDuration)
+	}
+}
+
+func TestLoadProfile_FederationTypeAutoDetect(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	writeConfig(t, tmp, `{"profiles": {
+		"sso":    {"sso_start_url": "https://d-xxx.awsapps.com/start"},
+		"direct": {"federated_role_arn": "arn:aws:iam::1:role/R"}
+	}}`)
+
+	sso, err := LoadProfile("sso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sso.FederationType != "sso" {
+		t.Errorf("sso auto-detect: got %q", sso.FederationType)
+	}
+
+	direct, err := LoadProfile("direct")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if direct.FederationType != "direct" {
+		t.Errorf("direct auto-detect: got %q", direct.FederationType)
+	}
+}
+
+func TestLoadProfile_NotFound(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	writeConfig(t, tmp, `{"profiles": {"other": {}}}`)
+
+	_, err := LoadProfile("missing")
+	if err == nil {
+		t.Fatal("expected error for missing profile")
+	}
+}
+
+func TestLoadProfile_NoConfigFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	_, err := LoadProfile("any")
+	if err == nil {
+		t.Fatal("expected error when config.json absent")
+	}
+}
+
+func TestLoadProfile_InvalidJSON(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	writeConfig(t, tmp, `not-json`)
+
+	_, err := LoadProfile("p")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestAutoDetectProfile_SingleNewFormat(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	writeConfig(t, tmp, `{"profiles": {"only": {}}}`)
+
+	got := AutoDetectProfile()
+	if got != "only" {
+		t.Errorf("got %q, want %q", got, "only")
+	}
+}
+
+func TestAutoDetectProfile_SingleOldFormat(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	writeConfig(t, tmp, `{"only": {}}`)
+
+	got := AutoDetectProfile()
+	if got != "only" {
+		t.Errorf("got %q, want %q", got, "only")
+	}
+}
+
+func TestAutoDetectProfile_MultipleReturnsEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	writeConfig(t, tmp, `{"profiles": {"a": {}, "b": {}}}`)
+
+	got := AutoDetectProfile()
+	if got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestAutoDetectProfile_NoFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	got := AutoDetectProfile()
+	if got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}

--- a/aws-oidc-auth/internal/federation/federation_test.go
+++ b/aws-oidc-auth/internal/federation/federation_test.go
@@ -1,0 +1,140 @@
+package federation
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"aws-oidc-auth/internal/jwt"
+)
+
+func TestBuildSessionName(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims jwt.Claims
+		want   string
+	}{
+		{
+			"uses sub",
+			jwt.Claims{"sub": "user-abc-123"},
+			"oidc-auth-user-abc-123",
+		},
+		{
+			"uses email local-part when no sub",
+			jwt.Claims{"email": "alice@example.com"},
+			"oidc-auth-alice",
+		},
+		{
+			"sanitizes special chars in sub",
+			jwt.Claims{"sub": "user/with:special chars"},
+			"oidc-auth-user-with-special-chars",
+		},
+		{
+			// sanitized sub is truncated to 32 chars, then "oidc-auth-" is prepended
+			"truncates long sub to 32 chars",
+			jwt.Claims{"sub": "abcdefghijklmnopqrstuvwxyz012345extra"},
+			"oidc-auth-abcdefghijklmnopqrstuvwxyz012345",
+		},
+		{
+			"falls back to oidc-auth when no sub or email",
+			jwt.Claims{},
+			"oidc-auth",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildSessionName(tc.claims)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRetryableAuthError(t *testing.T) {
+	retryable := []string{
+		"InvalidParameterException",
+		"NotAuthorizedException",
+		"ValidationError",
+		"Invalid AccessKeyId",
+		"ExpiredToken",
+		"Invalid JWT",
+		"Token is not from a supported provider",
+	}
+	for _, msg := range retryable {
+		t.Run(msg, func(t *testing.T) {
+			if !IsRetryableAuthError(errors.New("some prefix: " + msg + " suffix")) {
+				t.Errorf("expected retryable for %q", msg)
+			}
+		})
+	}
+
+	if IsRetryableAuthError(nil) {
+		t.Error("nil error should not be retryable")
+	}
+	if IsRetryableAuthError(errors.New("random error")) {
+		t.Error("unrelated error should not be retryable")
+	}
+}
+
+func TestDetermineLoginKey_Cognito(t *testing.T) {
+	claims := jwt.Claims{"iss": "https://cognito-idp.us-east-1.amazonaws.com/pool-id"}
+	got := determineLoginKey("cognito", "fallback.domain", claims)
+	want := "cognito-idp.us-east-1.amazonaws.com/pool-id"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestDetermineLoginKey_CognitoFallback(t *testing.T) {
+	// No iss claim → use providerDomain
+	got := determineLoginKey("cognito", "my.pool.domain", jwt.Claims{})
+	if got != "my.pool.domain" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestDetermineLoginKey_NonCognito(t *testing.T) {
+	got := determineLoginKey("okta", "dev-123.okta.com", jwt.Claims{"iss": "https://dev-123.okta.com"})
+	if got != "dev-123.okta.com" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestTemporaryEnvClear(t *testing.T) {
+	t.Setenv("AWS_PROFILE", "test-profile")
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKID")
+
+	restore := TemporaryEnvClear()
+
+	if os.Getenv("AWS_PROFILE") != "" {
+		t.Error("AWS_PROFILE should be cleared")
+	}
+	if os.Getenv("AWS_ACCESS_KEY_ID") != "" {
+		t.Error("AWS_ACCESS_KEY_ID should be cleared")
+	}
+
+	restore()
+
+	if os.Getenv("AWS_PROFILE") != "test-profile" {
+		t.Errorf("AWS_PROFILE not restored: got %q", os.Getenv("AWS_PROFILE"))
+	}
+	if os.Getenv("AWS_ACCESS_KEY_ID") != "AKID" {
+		t.Errorf("AWS_ACCESS_KEY_ID not restored: got %q", os.Getenv("AWS_ACCESS_KEY_ID"))
+	}
+}
+
+func TestClearAndRestoreAWSEnv(t *testing.T) {
+	t.Setenv("AWS_SESSION_TOKEN", "session-tok")
+
+	saved := clearAWSEnv()
+	if os.Getenv("AWS_SESSION_TOKEN") != "" {
+		t.Error("AWS_SESSION_TOKEN should be cleared")
+	}
+
+	restoreEnv(saved)
+	if os.Getenv("AWS_SESSION_TOKEN") != "session-tok" {
+		t.Errorf("AWS_SESSION_TOKEN not restored: got %q", os.Getenv("AWS_SESSION_TOKEN"))
+	}
+}

--- a/aws-oidc-auth/internal/portlock/lock_test.go
+++ b/aws-oidc-auth/internal/portlock/lock_test.go
@@ -1,0 +1,85 @@
+package portlock
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestTryAcquire_Free(t *testing.T) {
+	ln, err := TryAcquire(0) // port 0 = OS picks a free port
+	if err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	// port 0 isn't supported by TryAcquire (it binds to 127.0.0.1:0 which always succeeds)
+	// so just verify we get a listener back and can close it
+	if ln == nil {
+		t.Fatal("expected non-nil listener for free port")
+	}
+	ln.Close()
+}
+
+func TestTryAcquire_Busy(t *testing.T) {
+	// Bind a port ourselves to make it busy
+	holder, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	defer holder.Close()
+
+	port := holder.Addr().(*net.TCPAddr).Port
+
+	ln, err := TryAcquire(port)
+	if err != nil {
+		t.Fatalf("TryAcquire returned unexpected error: %v", err)
+	}
+	if ln != nil {
+		ln.Close()
+		t.Error("expected nil listener for busy port")
+	}
+}
+
+func TestWaitForRelease_AlreadyFree(t *testing.T) {
+	// Find a free port without holding it
+	tmp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := tmp.Addr().(*net.TCPAddr).Port
+	tmp.Close()
+
+	if !WaitForRelease(port, 2*time.Second) {
+		t.Error("expected WaitForRelease=true for an already-free port")
+	}
+}
+
+func TestWaitForRelease_Timeout(t *testing.T) {
+	holder, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	defer holder.Close()
+
+	port := holder.Addr().(*net.TCPAddr).Port
+
+	if WaitForRelease(port, 600*time.Millisecond) {
+		t.Error("expected WaitForRelease=false while port is held")
+	}
+}
+
+func TestWaitForRelease_ReleasedDuringWait(t *testing.T) {
+	holder, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	port := holder.Addr().(*net.TCPAddr).Port
+
+	go func() {
+		time.Sleep(400 * time.Millisecond)
+		holder.Close()
+	}()
+
+	if !WaitForRelease(port, 3*time.Second) {
+		t.Error("expected WaitForRelease=true after port released")
+	}
+}

--- a/aws-oidc-auth/internal/provider/endpoints_test.go
+++ b/aws-oidc-auth/internal/provider/endpoints_test.go
@@ -1,0 +1,32 @@
+package provider
+
+import "testing"
+
+func TestIsKnown(t *testing.T) {
+	known := []string{"okta", "auth0", "azure", "cognito"}
+	for _, p := range known {
+		if !IsKnown(p) {
+			t.Errorf("IsKnown(%q) = false, want true", p)
+		}
+	}
+	if IsKnown("unknown") {
+		t.Error("IsKnown(unknown) = true, want false")
+	}
+	if IsKnown("") {
+		t.Error("IsKnown('') = true, want false")
+	}
+}
+
+func TestConfigs_AllKnownHaveEndpoints(t *testing.T) {
+	for name, cfg := range Configs {
+		if cfg.AuthorizeEndpoint == "" {
+			t.Errorf("provider %q missing AuthorizeEndpoint", name)
+		}
+		if cfg.TokenEndpoint == "" {
+			t.Errorf("provider %q missing TokenEndpoint", name)
+		}
+		if cfg.Scopes == "" {
+			t.Errorf("provider %q missing Scopes", name)
+		}
+	}
+}

--- a/aws-oidc-auth/internal/sso/cache_test.go
+++ b/aws-oidc-auth/internal/sso/cache_test.go
@@ -1,0 +1,82 @@
+package sso
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWriteAndReadCachedToken(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	future := time.Now().Add(1 * time.Hour).UTC().Format("2006-01-02T15:04:05UTC")
+	tok := &CachedToken{
+		StartURL:    "https://d-test.awsapps.com/start",
+		Region:      "us-east-1",
+		AccessToken: "access-token-value",
+		ExpiresAt:   future,
+	}
+
+	if err := WriteCachedToken(tok); err != nil {
+		t.Fatalf("WriteCachedToken: %v", err)
+	}
+
+	got, err := ReadCachedToken("https://d-test.awsapps.com/start")
+	if err != nil {
+		t.Fatalf("ReadCachedToken: %v", err)
+	}
+	if got.AccessToken != "access-token-value" {
+		t.Errorf("AccessToken: got %q", got.AccessToken)
+	}
+	if got.Region != "us-east-1" {
+		t.Errorf("Region: got %q", got.Region)
+	}
+}
+
+func TestIsTokenValid(t *testing.T) {
+	future := time.Now().Add(1 * time.Hour).UTC().Format("2006-01-02T15:04:05UTC")
+	past := time.Now().Add(-1 * time.Hour).UTC().Format("2006-01-02T15:04:05UTC")
+	near := time.Now().Add(3 * time.Minute).UTC().Format("2006-01-02T15:04:05UTC")
+
+	tests := []struct {
+		name  string
+		tok   *CachedToken
+		valid bool
+	}{
+		{"nil token", nil, false},
+		{"empty access token", &CachedToken{ExpiresAt: future}, false},
+		{"empty expiresAt", &CachedToken{AccessToken: "t"}, false},
+		{"future valid", &CachedToken{AccessToken: "t", ExpiresAt: future}, true},
+		{"past expired", &CachedToken{AccessToken: "t", ExpiresAt: past}, false},
+		{"within 5-min buffer", &CachedToken{AccessToken: "t", ExpiresAt: near}, false},
+		{"invalid format", &CachedToken{AccessToken: "t", ExpiresAt: "not-a-date"}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsTokenValid(tc.tok); got != tc.valid {
+				t.Errorf("IsTokenValid=%v, want %v", got, tc.valid)
+			}
+		})
+	}
+}
+
+func TestIsTokenValid_RFC3339Format(t *testing.T) {
+	future := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	tok := &CachedToken{AccessToken: "t", ExpiresAt: future}
+	if !IsTokenValid(tok) {
+		t.Error("expected valid for RFC3339 future timestamp")
+	}
+}
+
+func TestReadCachedToken_NoFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	_, err := ReadCachedToken("https://d-nonexistent.awsapps.com/start")
+	if err == nil {
+		t.Error("expected error for absent cache file")
+	}
+}

--- a/aws-oidc-auth/internal/storage/storage_test.go
+++ b/aws-oidc-auth/internal/storage/storage_test.go
@@ -1,0 +1,212 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"aws-oidc-auth/internal/federation"
+)
+
+func TestReadWriteCredentialsFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	creds := &federation.AWSCredentials{
+		Version:         1,
+		AccessKeyID:     "AKID",
+		SecretAccessKey: "SECRET",
+		SessionToken:    "TOKEN",
+		Expiration:      "2030-01-01T00:00:00Z",
+	}
+
+	if err := SaveToCredentialsFile(creds, "myprofile"); err != nil {
+		t.Fatalf("SaveToCredentialsFile: %v", err)
+	}
+
+	got, err := ReadFromCredentialsFile("myprofile")
+	if err != nil {
+		t.Fatalf("ReadFromCredentialsFile: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected credentials, got nil")
+	}
+	if got.AccessKeyID != "AKID" {
+		t.Errorf("AccessKeyID: got %q", got.AccessKeyID)
+	}
+	if got.SecretAccessKey != "SECRET" {
+		t.Errorf("SecretAccessKey: got %q", got.SecretAccessKey)
+	}
+	if got.SessionToken != "TOKEN" {
+		t.Errorf("SessionToken: got %q", got.SessionToken)
+	}
+	if got.Expiration != "2030-01-01T00:00:00Z" {
+		t.Errorf("Expiration: got %q", got.Expiration)
+	}
+}
+
+func TestReadCredentialsFile_NoFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	got, err := ReadFromCredentialsFile("any")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for absent file, got %+v", got)
+	}
+}
+
+func TestReadCredentialsFile_MissingSection(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	credPath := filepath.Join(tmp, ".aws", "credentials")
+	os.MkdirAll(filepath.Dir(credPath), 0700)
+	os.WriteFile(credPath, []byte("[other]\naws_access_key_id = X\n"), 0600)
+
+	got, err := ReadFromCredentialsFile("missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for absent section, got %+v", got)
+	}
+}
+
+func TestSaveToCredentialsFile_UpdatesExistingProfile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	first := &federation.AWSCredentials{Version: 1, AccessKeyID: "FIRST", SecretAccessKey: "S1", SessionToken: "T1"}
+	second := &federation.AWSCredentials{Version: 1, AccessKeyID: "SECOND", SecretAccessKey: "S2", SessionToken: "T2"}
+
+	if err := SaveToCredentialsFile(first, "p"); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveToCredentialsFile(second, "p"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadFromCredentialsFile("p")
+	if err != nil || got == nil {
+		t.Fatalf("read after update: err=%v got=%v", err, got)
+	}
+	if got.AccessKeyID != "SECOND" {
+		t.Errorf("expected SECOND, got %q", got.AccessKeyID)
+	}
+}
+
+func TestIsExpiredDummy(t *testing.T) {
+	if !IsExpiredDummy(&federation.AWSCredentials{AccessKeyID: "EXPIRED"}) {
+		t.Error("expected true for EXPIRED")
+	}
+	if IsExpiredDummy(&federation.AWSCredentials{AccessKeyID: "AKID"}) {
+		t.Error("expected false for real key")
+	}
+	if IsExpiredDummy(nil) {
+		t.Error("expected false for nil")
+	}
+}
+
+func TestParseExpirationSeconds(t *testing.T) {
+	future := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	secs := ParseExpirationSeconds(future)
+	if secs < 3500 || secs > 3700 {
+		t.Errorf("expected ~3600, got %f", secs)
+	}
+
+	past := "2000-01-01T00:00:00Z"
+	if ParseExpirationSeconds(past) >= 0 {
+		// negative means expired — we just want it to not be zero-like
+	}
+
+	if ParseExpirationSeconds("") != 0 {
+		t.Error("empty string should return 0")
+	}
+	if ParseExpirationSeconds("not-a-date") != 0 {
+		t.Error("invalid string should return 0")
+	}
+}
+
+func TestSaveAndGetMonitoringToken_File(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_OIDC_AUTH_MONITORING_TOKEN", "")
+
+	futureExp := time.Now().Add(2 * time.Hour).Unix()
+	claims := map[string]interface{}{
+		"exp":   float64(futureExp),
+		"email": "user@example.com",
+	}
+
+	if err := SaveMonitoringToken("p", "session", "id-token-value", claims); err != nil {
+		t.Fatalf("SaveMonitoringToken: %v", err)
+	}
+
+	token, err := GetMonitoringToken("p", "session")
+	if err != nil {
+		t.Fatalf("GetMonitoringToken: %v", err)
+	}
+	if token != "id-token-value" {
+		t.Errorf("got %q, want %q", token, "id-token-value")
+	}
+}
+
+func TestGetMonitoringToken_FromEnv(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_OIDC_AUTH_MONITORING_TOKEN", "env-token")
+
+	token, err := GetMonitoringToken("any", "session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "env-token" {
+		t.Errorf("got %q, want %q", token, "env-token")
+	}
+}
+
+func TestGetMonitoringToken_Expired(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_OIDC_AUTH_MONITORING_TOKEN", "")
+
+	pastExp := time.Now().Add(-1 * time.Hour).Unix()
+	claims := map[string]interface{}{"exp": float64(pastExp)}
+	if err := SaveMonitoringToken("p", "session", "stale-token", claims); err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := GetMonitoringToken("p", "session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "" {
+		t.Errorf("expected empty for expired token, got %q", token)
+	}
+}
+
+func TestGetMonitoringToken_NoFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("AWS_OIDC_AUTH_MONITORING_TOKEN", "")
+
+	token, err := GetMonitoringToken("absent", "session")
+	if err != nil && !os.IsNotExist(err) {
+		// Underlying file error is acceptable
+	}
+	if token != "" {
+		t.Errorf("expected empty, got %q", token)
+	}
+}

--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/jwt-middleware/.gitignore
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/jwt-middleware/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+*.pyc
+.coverage
+coverage.xml
+htmlcov/

--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/jwt-middleware/test_app.py
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/jwt-middleware/test_app.py
@@ -1,0 +1,494 @@
+"""
+Tests for jwt-middleware app.py
+
+Uses moto to mock DynamoDB and responses to mock HTTP calls, so no real AWS
+credentials or external network access is required.
+"""
+import importlib
+import json
+import os
+import sys
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from moto import mock_aws
+
+# ---------------------------------------------------------------------------
+# Helpers to generate RS256 key pair and test JWTs
+# ---------------------------------------------------------------------------
+
+def generate_rsa_key_pair():
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+    public_key = private_key.public_key()
+    return private_key, public_key
+
+
+def make_jwt(private_key, kid="test-kid", claims_override=None, expired=False):
+    import jwt as pyjwt
+    now = datetime.now(tz=timezone.utc)
+    exp = now - timedelta(seconds=10) if expired else now + timedelta(hours=1)
+    payload = {
+        "sub": "user-123",
+        "email": "user@example.com",
+        "name": "Test User",
+        "groups": ["engineers"],
+        "iss": "https://idp.example.com",
+        "aud": "test-audience",
+        "iat": int(now.timestamp()),
+        "exp": int(exp.timestamp()),
+    }
+    if claims_override:
+        payload.update(claims_override)
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pyjwt.encode(payload, pem, algorithm="RS256", headers={"kid": kid})
+
+
+def build_jwks(public_key, kid="test-kid"):
+    """Return a JWKS dict containing the given public key."""
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+    from cryptography.hazmat.primitives import serialization
+    import base64, struct
+
+    pub_numbers = public_key.public_key().public_numbers() if hasattr(public_key, 'public_key') else public_key.public_numbers()
+
+    def int_to_base64url(n):
+        length = (n.bit_length() + 7) // 8
+        return base64.urlsafe_b64encode(n.to_bytes(length, "big")).rstrip(b"=").decode()
+
+    return {
+        "keys": [{
+            "kty": "RSA",
+            "kid": kid,
+            "use": "sig",
+            "alg": "RS256",
+            "n": int_to_base64url(pub_numbers.n),
+            "e": int_to_base64url(pub_numbers.e),
+        }]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixture: import app with mocked environment and AWS
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def rsa_keys():
+    private_key, public_key = generate_rsa_key_pair()
+    return private_key, public_key
+
+
+@pytest.fixture()
+def app_client(rsa_keys, monkeypatch):
+    """
+    Yields a Flask test client with:
+    - moto mocking DynamoDB
+    - env vars set to plausible values
+    - JWKS endpoint mocked via patch
+    """
+    private_key, public_key = rsa_keys
+    jwks = build_jwks(public_key)
+
+    env = {
+        "JWKS_URL": "https://idp.example.com/.well-known/jwks.json",
+        "JWT_AUDIENCE": "test-audience",
+        "JWT_ISSUER": "https://idp.example.com",
+        "LITELLM_URL": "http://litellm:4000",
+        "LITELLM_MASTER_KEY": "master-key-test",
+        "DYNAMODB_TABLE": "codex-user-keys",
+        "AWS_REGION": "us-east-1",
+        "AWS_DEFAULT_REGION": "us-east-1",
+        "AWS_ACCESS_KEY_ID": "testing",
+        "AWS_SECRET_ACCESS_KEY": "testing",
+        "AWS_SECURITY_TOKEN": "testing",
+        "AWS_SESSION_TOKEN": "testing",
+    }
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    with mock_aws():
+        # Create the DynamoDB table that app.py expects
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        dynamodb.create_table(
+            TableName="codex-user-keys",
+            KeySchema=[{"AttributeName": "user_id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "user_id", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        # Force fresh module import so it picks up mocked env + DynamoDB
+        if "app" in sys.modules:
+            del sys.modules["app"]
+
+        with patch("requests.Session.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = jwks
+            mock_resp.raise_for_status = MagicMock()
+            mock_get.return_value = mock_resp
+
+            import app as flask_app
+
+            # Clear lru_cache so each test fixture gets a fresh JWKS fetch
+            flask_app.get_jwks.cache_clear()
+            flask_app.jwks_cache.clear()
+            flask_app.user_key_cache.clear()
+
+            flask_app.app.config["TESTING"] = True
+            client = flask_app.app.test_client()
+            yield client, flask_app, private_key
+
+
+# ---------------------------------------------------------------------------
+# Health check
+# ---------------------------------------------------------------------------
+
+class TestHealth:
+    def test_health_returns_200(self, app_client):
+        client, _, _ = app_client
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "healthy"
+
+
+# ---------------------------------------------------------------------------
+# JWT validation
+# ---------------------------------------------------------------------------
+
+class TestJWTValidation:
+    def test_missing_auth_header_returns_401(self, app_client):
+        client, _, _ = app_client
+        resp = client.get("/api/my-key")
+        assert resp.status_code == 401
+        assert "Missing or invalid" in resp.get_json()["error"]
+
+    def test_non_bearer_token_returns_401(self, app_client):
+        client, _, _ = app_client
+        resp = client.get("/api/my-key", headers={"Authorization": "Basic abc"})
+        assert resp.status_code == 401
+
+    def test_invalid_jwt_returns_401(self, app_client):
+        client, _, _ = app_client
+        resp = client.get("/api/my-key", headers={"Authorization": "Bearer not.a.jwt"})
+        assert resp.status_code == 401
+
+    def test_expired_jwt_returns_401(self, app_client, rsa_keys):
+        client, flask_app, private_key = app_client
+        token = make_jwt(private_key, expired=True)
+        flask_app.get_jwks.cache_clear()
+
+        resp = client.get("/api/my-key", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 401
+        assert "expired" in resp.get_json()["error"].lower()
+
+    def test_token_without_sub_returns_401(self, app_client):
+        client, flask_app, private_key = app_client
+        flask_app.get_jwks.cache_clear()
+        token = make_jwt(private_key, claims_override={"sub": None})
+        # sub=None still sets the key; need to remove it entirely
+        import jwt as pyjwt
+        from datetime import datetime, timezone, timedelta
+        from cryptography.hazmat.primitives import serialization
+        now = datetime.now(tz=timezone.utc)
+        payload = {
+            "email": "user@example.com",
+            "iss": "https://idp.example.com",
+            "aud": "test-audience",
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(hours=1)).timestamp()),
+        }
+        pem = private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+        token = pyjwt.encode(payload, pem, algorithm="RS256", headers={"kid": "test-kid"})
+        resp = client.get("/api/my-key", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# validate_jwt_token unit tests (direct calls)
+# ---------------------------------------------------------------------------
+
+class TestValidateJwtToken:
+    def test_valid_token_returns_user_info(self, app_client):
+        _, flask_app, private_key = app_client
+        flask_app.get_jwks.cache_clear()
+        token = make_jwt(private_key)
+        info = flask_app.validate_jwt_token(token)
+        assert info["user_id"] == "user-123"
+        assert info["email"] == "user@example.com"
+        assert info["groups"] == ["engineers"]
+
+    def test_no_jwks_url_raises(self, app_client, monkeypatch):
+        _, flask_app, private_key = app_client
+        monkeypatch.setattr(flask_app, "JWKS_URL", None)
+        with pytest.raises(ValueError, match="JWKS_URL"):
+            flask_app.validate_jwt_token("any.token.value")
+
+    def test_unknown_kid_raises(self, app_client):
+        _, flask_app, private_key = app_client
+        flask_app.get_jwks.cache_clear()
+        token = make_jwt(private_key, kid="unknown-kid")
+        with pytest.raises(ValueError, match="not found in JWKS"):
+            flask_app.validate_jwt_token(token)
+
+
+# ---------------------------------------------------------------------------
+# API key caching (DynamoDB + in-memory)
+# ---------------------------------------------------------------------------
+
+class TestApiKeyCaching:
+    def test_get_cached_api_key_returns_none_when_absent(self, app_client):
+        _, flask_app, _ = app_client
+        flask_app.user_key_cache.clear()
+        result = flask_app.get_cached_api_key("nonexistent-user")
+        assert result is None
+
+    def test_cache_and_retrieve_api_key(self, app_client):
+        _, flask_app, _ = app_client
+        flask_app.user_key_cache.clear()
+        user_info = {"user_id": "u-1", "email": "u@example.com", "name": "U", "groups": []}
+        flask_app.cache_api_key("u-1", "sk-test-key", user_info)
+        assert flask_app.get_cached_api_key("u-1") == "sk-test-key"
+
+    def test_in_memory_cache_hit_skips_dynamodb(self, app_client):
+        _, flask_app, _ = app_client
+        flask_app.user_key_cache["cached-user"] = "sk-cached"
+        result = flask_app.get_cached_api_key("cached-user")
+        assert result == "sk-cached"
+
+
+# ---------------------------------------------------------------------------
+# /api/my-key endpoint (get_or_create flow)
+# ---------------------------------------------------------------------------
+
+class TestGetMyKey:
+    def _auth_header(self, private_key):
+        return {"Authorization": f"Bearer {make_jwt(private_key)}"}
+
+    def test_returns_api_key_for_valid_jwt_new_user(self, app_client):
+        client, flask_app, private_key = app_client
+        flask_app.get_jwks.cache_clear()
+        flask_app.user_key_cache.clear()
+
+        with patch.object(flask_app, "create_litellm_api_key", return_value="sk-new-key"):
+            resp = client.get("/api/my-key", headers=self._auth_header(private_key))
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["api_key"] == "sk-new-key"
+        assert data["email"] == "user@example.com"
+
+    def test_returns_cached_key_for_known_user(self, app_client):
+        client, flask_app, private_key = app_client
+        flask_app.get_jwks.cache_clear()
+        flask_app.user_key_cache["user-123"] = "sk-cached-key"
+
+        resp = client.get("/api/my-key", headers=self._auth_header(private_key))
+        assert resp.status_code == 200
+        assert resp.get_json()["api_key"] == "sk-cached-key"
+
+    def test_returns_500_when_key_creation_fails(self, app_client):
+        client, flask_app, private_key = app_client
+        flask_app.get_jwks.cache_clear()
+        flask_app.user_key_cache.clear()
+
+        with patch.object(flask_app, "create_litellm_api_key", side_effect=Exception("LiteLLM down")):
+            resp = client.get("/api/my-key", headers=self._auth_header(private_key))
+
+        assert resp.status_code == 500
+        assert "Key management failed" in resp.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# Proxy endpoint
+# ---------------------------------------------------------------------------
+
+class TestProxy:
+    def _auth_header(self, private_key):
+        return {"Authorization": f"Bearer {make_jwt(private_key)}"}
+
+    def test_proxy_forwards_request_to_litellm(self, app_client):
+        client, flask_app, private_key = app_client
+        flask_app.get_jwks.cache_clear()
+        flask_app.user_key_cache["user-123"] = "sk-proxy-key"
+
+        mock_litellm_resp = MagicMock()
+        mock_litellm_resp.status_code = 200
+        mock_litellm_resp.headers = {"Content-Type": "application/json"}
+        mock_litellm_resp.iter_content = MagicMock(return_value=[b'{"result":"ok"}'])
+
+        with patch.object(flask_app.session, "request", return_value=mock_litellm_resp) as mock_req:
+            resp = client.post(
+                "/v1/chat/completions",
+                headers={**self._auth_header(private_key), "Content-Type": "application/json"},
+                json={"model": "gpt-4", "messages": []},
+            )
+
+        assert resp.status_code == 200
+        # Verify the upstream call used the user's LiteLLM key
+        call_headers = mock_req.call_args.kwargs["headers"]
+        assert call_headers["Authorization"] == "Bearer sk-proxy-key"
+
+    def test_proxy_returns_401_without_auth(self, app_client):
+        client, _, _ = app_client
+        resp = client.post("/v1/chat/completions", json={})
+        assert resp.status_code == 401
+
+    def test_proxy_returns_500_on_litellm_failure(self, app_client):
+        client, flask_app, private_key = app_client
+        flask_app.get_jwks.cache_clear()
+        flask_app.user_key_cache["user-123"] = "sk-key"
+
+        with patch.object(flask_app.session, "request", side_effect=Exception("connection refused")):
+            resp = client.get("/v1/models", headers=self._auth_header(private_key))
+
+        assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# create_litellm_api_key unit tests
+# ---------------------------------------------------------------------------
+
+class TestCreateLitellmApiKey:
+    def test_returns_key_on_success(self, app_client):
+        _, flask_app, _ = app_client
+        user_info = {"user_id": "u-2", "email": "u2@example.com", "name": "U2", "groups": []}
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"key": "sk-created"}
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(flask_app.session, "post", return_value=mock_resp):
+            key = flask_app.create_litellm_api_key(user_info)
+
+        assert key == "sk-created"
+
+    def test_raises_when_key_missing_in_response(self, app_client):
+        _, flask_app, _ = app_client
+        user_info = {"user_id": "u-3", "email": "u3@example.com", "name": "U3", "groups": []}
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}  # no "key" field
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(flask_app.session, "post", return_value=mock_resp):
+            with pytest.raises(Exception, match="did not return an API key"):
+                flask_app.create_litellm_api_key(user_info)
+
+    def test_raises_on_409_conflict(self, app_client):
+        _, flask_app, _ = app_client
+        user_info = {"user_id": "u-4", "email": "u4@example.com", "name": "U4", "groups": []}
+
+        import requests as req_lib
+        http_err = req_lib.exceptions.HTTPError(response=MagicMock(status_code=409))
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = http_err
+
+        with patch.object(flask_app.session, "post", return_value=mock_resp):
+            with pytest.raises(Exception, match="Key already exists"):
+                flask_app.create_litellm_api_key(user_info)
+
+    def test_raises_on_non_409_http_error(self, app_client):
+        _, flask_app, _ = app_client
+        user_info = {"user_id": "u-5", "email": "u5@example.com", "name": "U5", "groups": []}
+
+        import requests as req_lib
+        http_err = req_lib.exceptions.HTTPError(response=MagicMock(status_code=500))
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = http_err
+
+        with patch.object(flask_app.session, "post", return_value=mock_resp):
+            with pytest.raises(Exception, match="Failed to create API key"):
+                flask_app.create_litellm_api_key(user_info)
+
+
+# ---------------------------------------------------------------------------
+# Additional edge case coverage
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_get_jwks_raises_on_fetch_failure(self, app_client):
+        _, flask_app, _ = app_client
+        flask_app.get_jwks.cache_clear()
+        with patch.object(flask_app.session, "get", side_effect=Exception("network error")):
+            with pytest.raises(Exception, match="network error"):
+                flask_app.get_jwks()
+
+    def test_validate_jwt_token_missing_kid_raises(self, app_client):
+        _, flask_app, private_key = app_client
+        flask_app.get_jwks.cache_clear()
+        import jwt as pyjwt
+        from datetime import datetime, timezone, timedelta
+        from cryptography.hazmat.primitives import serialization
+        now = datetime.now(tz=timezone.utc)
+        payload = {
+            "sub": "u", "email": "u@x.com", "iss": "https://idp.example.com",
+            "aud": "test-audience",
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(hours=1)).timestamp()),
+        }
+        pem = private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+        # Encode without kid header
+        token = pyjwt.encode(payload, pem, algorithm="RS256")
+        with pytest.raises(ValueError, match="missing 'kid'"):
+            flask_app.validate_jwt_token(token)
+
+    def test_validate_jwt_wrong_audience_raises(self, app_client):
+        _, flask_app, private_key = app_client
+        flask_app.get_jwks.cache_clear()
+        token = make_jwt(private_key, claims_override={"aud": "wrong-audience"})
+        with pytest.raises(ValueError, match="Invalid audience|Invalid JWT"):
+            flask_app.validate_jwt_token(token)
+
+    def test_validate_jwt_wrong_issuer_raises(self, app_client):
+        _, flask_app, private_key = app_client
+        flask_app.get_jwks.cache_clear()
+        token = make_jwt(private_key, claims_override={"iss": "https://evil.com"})
+        with pytest.raises(ValueError, match="Invalid issuer|Invalid JWT"):
+            flask_app.validate_jwt_token(token)
+
+    def test_get_cached_api_key_dynamodb_error_returns_none(self, app_client):
+        _, flask_app, _ = app_client
+        flask_app.user_key_cache.clear()
+        with patch.object(flask_app.user_key_table, "get_item", side_effect=Exception("DynamoDB down")):
+            result = flask_app.get_cached_api_key("any-user")
+        assert result is None
+
+    def test_get_cached_api_key_found_in_dynamodb(self, app_client):
+        _, flask_app, _ = app_client
+        flask_app.user_key_cache.clear()
+        with patch.object(flask_app.user_key_table, "get_item",
+                          return_value={"Item": {"user_id": "db-user", "api_key": "sk-from-db"}}):
+            result = flask_app.get_cached_api_key("db-user")
+        assert result == "sk-from-db"
+        assert flask_app.user_key_cache.get("db-user") == "sk-from-db"
+
+    def test_cache_api_key_dynamodb_error_is_swallowed(self, app_client):
+        _, flask_app, _ = app_client
+        flask_app.user_key_cache.clear()
+        user_info = {"user_id": "err-user", "email": "e@x.com", "name": "E", "groups": []}
+        with patch.object(flask_app.user_key_table, "put_item", side_effect=Exception("write error")):
+            flask_app.cache_api_key("err-user", "sk-x", user_info)
+        # In-memory cache should still be set
+        assert flask_app.user_key_cache.get("err-user") == "sk-x"

--- a/otel-helper/.gitignore
+++ b/otel-helper/.gitignore
@@ -1,3 +1,5 @@
 bin/
 /otel-helper
 /otel-helper.exe
+coverage.out
+coverage.html

--- a/otel-helper/Makefile
+++ b/otel-helper/Makefile
@@ -2,12 +2,17 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 LDFLAGS := -s -w -X otel-helper/internal/version.Version=$(VERSION)
 OUT ?= bin
 
-.PHONY: all test clean fmt vet macos-arm64 macos-intel linux-x64 linux-arm64 windows
+.PHONY: all test coverage clean fmt vet macos-arm64 macos-intel linux-x64 linux-arm64 windows
 
 all: macos-arm64 macos-intel linux-x64 linux-arm64 windows
 
 test:
 	go test ./... -v
+
+coverage:
+	go test ./... -coverprofile=coverage.out -covermode=atomic
+	go tool cover -func=coverage.out
+	go tool cover -html=coverage.out -o coverage.html
 
 fmt:
 	go fmt ./...


### PR DESCRIPTION
## Summary

- **aws-oidc-auth**: unit tests for `cmd/credential-process`, `internal/config`, `internal/storage`, `internal/sso`, `internal/portlock`, `internal/federation`, and `internal/provider/endpoints`
- **otel-helper**: coverage target added to Makefile; existing tests verified
- **jwt-middleware**: 29 pytest tests for `app.py` reaching 96% coverage — JWT validation, API key caching (DynamoDB + in-memory), proxy forwarding, key creation, and all error paths (409 conflict, DynamoDB failures, wrong audience/issuer, missing `kid` header)

## Test plan

- [ ] `cd aws-oidc-auth && make coverage` — all packages pass, coverage report generated
- [ ] `cd otel-helper && make coverage` — all packages pass
- [ ] `cd guidance-for-codex-on-amazon-bedrock/deployment/litellm/jwt-middleware && .venv/bin/pytest test_app.py -v --cov=app --cov-report=term-missing` — 29 passed, 96% coverage