### PR TITLE
fix(litellm): migrate gateway to bedrock_mantle provider, clarify GPT-5.x API compatibility

### DIFF
--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/.env.example
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/.env.example
@@ -3,11 +3,12 @@ AWS_REGION=us-west-2
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
-# Bedrock Mantle API key — required for GPT-5.x and GPT-OSS models
+# Bedrock Mantle API key — required for GPT-5.x models (gpt-5.4, gpt-5.5)
+# Key must be scoped to us-east-2 (both model endpoints use that region by default).
 # Generate a short-term key (valid 12h) from your IAM credentials:
 #   pip install aws-bedrock-token-generator
-#   python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())"
-# For production, refresh this before each ECS deployment or use a long-term key (exploration only).
+#   AWS_DEFAULT_REGION=us-east-2 python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())"
+# For production, refresh this before each ECS deployment.
 BEDROCK_MANTLE_API_KEY=
 
 # LiteLLM master key — used by admins to manage the gateway (rotate regularly)

--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/.env.example
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/.env.example
@@ -1,7 +1,14 @@
-# AWS credentials — use either static keys or an IAM role (recommended for ECS)
-AWS_REGION=us-east-1
+# AWS credentials — use an IAM role (recommended for ECS) or static keys
+AWS_REGION=us-west-2
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
+
+# Bedrock Mantle API key — required for GPT-5.x and GPT-OSS models
+# Generate a short-term key (valid 12h) from your IAM credentials:
+#   pip install aws-bedrock-token-generator
+#   python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())"
+# For production, refresh this before each ECS deployment or use a long-term key (exploration only).
+BEDROCK_MANTLE_API_KEY=
 
 # LiteLLM master key — used by admins to manage the gateway (rotate regularly)
 LITELLM_MASTER_KEY=sk-change-me

--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/ecs/litellm-ecs.yaml
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/ecs/litellm-ecs.yaml
@@ -299,19 +299,30 @@ Resources:
           Environment:
             - Name: AWS_REGION
               Value: !Ref AwsRegion
-            # LiteLLM OTEL configuration (standard OpenTelemetry env vars)
-            - Name: OTEL_EXPORTER
-              Value: otlp_http
-            - Name: OTEL_ENDPOINT
-              Value: !ImportValue
-                Fn::Sub: "${OtelStackName}-endpoint"
-            - Name: OTEL_SERVICE_NAME
-              Value: litellm-gateway
-            # Enable metrics export (required for LiteLLM OTEL integration)
-            - Name: LITELLM_OTEL_INTEGRATION_ENABLE_METRICS
-              Value: "true"
             - Name: DATABASE_URL
               Value: !Sub "postgresql://litellm:${DBPassword}@${RDSInstance.Endpoint.Address}:5432/litellm"
+            # LiteLLM OTEL configuration — only injected when OTel is enabled
+            - !If
+              - OtelEnabled
+              - Name: OTEL_EXPORTER
+                Value: otlp_http
+              - !Ref AWS::NoValue
+            - !If
+              - OtelEnabled
+              - Name: OTEL_ENDPOINT
+                Value: !ImportValue
+                  Fn::Sub: "${OtelStackName}-endpoint"
+              - !Ref AWS::NoValue
+            - !If
+              - OtelEnabled
+              - Name: OTEL_SERVICE_NAME
+                Value: litellm-gateway
+              - !Ref AWS::NoValue
+            - !If
+              - OtelEnabled
+              - Name: LITELLM_OTEL_INTEGRATION_ENABLE_METRICS
+                Value: "true"
+              - !Ref AWS::NoValue
           Secrets:
             - Name: LITELLM_MASTER_KEY
               ValueFrom: !Sub "${LiteLLMSecret}:LITELLM_MASTER_KEY::"

--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/ecs/litellm-ecs.yaml
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/ecs/litellm-ecs.yaml
@@ -27,6 +27,14 @@ Parameters:
     NoEcho: true
     Description: LiteLLM master key - stored in Secrets Manager
 
+  BedrockMantleApiKey:
+    Type: String
+    NoEcho: true
+    Description: >
+      Bedrock Mantle API key for GPT-5.x and GPT-OSS models. Generate a short-term key
+      (valid 12h) using: pip install aws-bedrock-token-generator &&
+      python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())"
+
   DBPassword:
     Type: String
     NoEcho: true
@@ -114,8 +122,8 @@ Resources:
   LiteLLMSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
-      Name: !Sub "${AWS::StackName}/litellm-master-key"
-      SecretString: !Sub '{"LITELLM_MASTER_KEY":"${LiteLLMMasterKey}"}'
+      Name: !Sub "${AWS::StackName}/litellm-secrets"
+      SecretString: !Sub '{"LITELLM_MASTER_KEY":"${LiteLLMMasterKey}","BEDROCK_MANTLE_API_KEY":"${BedrockMantleApiKey}"}'
 
   # --- IAM ---
 
@@ -136,7 +144,9 @@ Resources:
           PolicyDocument:
             Statement:
               - Effect: Allow
-                Action: secretsmanager:GetSecretValue
+                Action:
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:DescribeSecret
                 Resource: !Ref LiteLLMSecret
 
   TaskRole:
@@ -158,6 +168,10 @@ Resources:
                   - bedrock:InvokeModel
                   - bedrock:InvokeModelWithResponseStream
                 Resource: !Sub "arn:${AWS::Partition}:bedrock:*::foundation-model/*"
+              - Effect: Allow
+                Action:
+                  - bedrock:CallWithBearerToken
+                Resource: "*"
         - PolicyName: CloudWatchLogs
           PolicyDocument:
             Statement:
@@ -301,6 +315,8 @@ Resources:
           Secrets:
             - Name: LITELLM_MASTER_KEY
               ValueFrom: !Sub "${LiteLLMSecret}:LITELLM_MASTER_KEY::"
+            - Name: BEDROCK_MANTLE_API_KEY
+              ValueFrom: !Sub "${LiteLLMSecret}:BEDROCK_MANTLE_API_KEY::"
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
@@ -6,13 +6,13 @@ model_list:
 
   - model_name: gpt-5.4
     litellm_params:
-      model: openai/openai.gpt-5.4
+      model: openai/responses/openai.gpt-5.4
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
       api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
   - model_name: gpt-5.5
     litellm_params:
-      model: openai/openai.gpt-5.5
+      model: openai/responses/openai.gpt-5.5
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
       api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
@@ -33,6 +33,5 @@ general_settings:
 
 litellm_settings:
   set_verbose: false
-  drop_params: true                          # silently drop unsupported OpenAI params
-  route_all_chat_openai_to_responses: true   # routes gpt-5.x chat/completions calls → Responses API
-  # callbacks: ["otel"]                      # uncomment + set OTEL_ENDPOINT env var if you wire up an OTel collector
+  drop_params: true    # silently drop unsupported OpenAI params
+  # callbacks: ["otel"]  # uncomment + set OTEL_ENDPOINT env var if you wire up an OTel collector

--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
@@ -8,13 +8,13 @@ model_list:
     litellm_params:
       model: openai/openai.gpt-5.4
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+      api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
   - model_name: gpt-5.5
     litellm_params:
       model: openai/openai.gpt-5.5
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"  # us-east-2 only
+      api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
@@ -1,45 +1,34 @@
 model_list:
-  # OpenAI GPT-5.x models via Bedrock Mantle
-  - model_name: gpt-5.5
-    litellm_params:
-      model: bedrock/openai.gpt-5.5
-      aws_region_name: us-east-2   # GPT-5.5 is us-east-2 only
+  # OpenAI GPT-OSS models via Amazon Bedrock Mantle (Chat Completions — compatible with Codex)
+  # Auth: set BEDROCK_MANTLE_API_KEY to a short-term Bedrock API key (valid 12h)
+  # Generate: pip install aws-bedrock-token-generator && python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())"
+  #
+  # Note: GPT-5.4 and GPT-5.5 only support the Responses API (not Chat Completions) and
+  # are therefore not compatible with Codex or LiteLLM's chat proxy. Use GPT-OSS models below.
 
-  - model_name: gpt-5.4
-    litellm_params:
-      model: bedrock/openai.gpt-5.4
-      aws_region_name: os.environ/AWS_REGION
-
-  # OpenAI OSS models via Bedrock (primary — for Codex)
   - model_name: gpt-4o
     litellm_params:
-      model: bedrock/openai.gpt-oss-safeguard-120b
-      aws_region_name: os.environ/AWS_REGION
+      model: bedrock_mantle/openai.gpt-oss-safeguard-120b
+      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
 
   - model_name: gpt-4o-mini
     litellm_params:
-      model: bedrock/openai.gpt-oss-safeguard-20b
-      aws_region_name: os.environ/AWS_REGION
+      model: bedrock_mantle/openai.gpt-oss-safeguard-20b
+      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
 
   - model_name: gpt-oss-120b
     litellm_params:
-      model: bedrock/openai.gpt-oss-120b-1:0
-      aws_region_name: os.environ/AWS_REGION
+      model: bedrock_mantle/openai.gpt-oss-120b
+      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
 
   - model_name: gpt-oss-20b
     litellm_params:
-      model: bedrock/openai.gpt-oss-20b-1:0
-      aws_region_name: os.environ/AWS_REGION
-
-  - model_name: gpt-oss-safeguard-120b
-    litellm_params:
-      model: bedrock/openai.gpt-oss-safeguard-120b
-      aws_region_name: os.environ/AWS_REGION
-
-  - model_name: gpt-oss-safeguard-20b
-    litellm_params:
-      model: bedrock/openai.gpt-oss-safeguard-20b
-      aws_region_name: os.environ/AWS_REGION
+      model: bedrock_mantle/openai.gpt-oss-20b
+      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
@@ -1,8 +1,8 @@
 model_list:
-  # OpenAI GPT-5.x models via Amazon Bedrock Mantle (Responses API, routed via LiteLLM)
+  # OpenAI GPT-5.x models via Amazon Bedrock Mantle
   # Auth: set BEDROCK_MANTLE_API_KEY to a short-term Bedrock API key (valid 12h)
   # Generate: pip install aws-bedrock-token-generator && python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())"
-  # Note: route_all_chat_openai_to_responses (below) transparently maps Chat Completions → Responses API
+  # Note: route_all_chat_openai_to_responses below transparently maps Chat Completions → Responses API
 
   - model_name: gpt-5.4
     litellm_params:
@@ -15,31 +15,6 @@ model_list:
       model: openai/openai.gpt-5.5
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
       api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"  # us-east-2 only
-
-  # OpenAI GPT-OSS models via Amazon Bedrock Mantle (Chat Completions — native support)
-  - model_name: gpt-4o
-    litellm_params:
-      model: openai/openai.gpt-oss-safeguard-120b
-      api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
-
-  - model_name: gpt-4o-mini
-    litellm_params:
-      model: openai/openai.gpt-oss-safeguard-20b
-      api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
-
-  - model_name: gpt-oss-120b
-    litellm_params:
-      model: openai/openai.gpt-oss-120b
-      api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
-
-  - model_name: gpt-oss-20b
-    litellm_params:
-      model: openai/openai.gpt-oss-20b
-      api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
@@ -1,34 +1,45 @@
 model_list:
-  # OpenAI GPT-OSS models via Amazon Bedrock Mantle (Chat Completions — compatible with Codex)
+  # OpenAI GPT-5.x models via Amazon Bedrock Mantle (Responses API, routed via LiteLLM)
   # Auth: set BEDROCK_MANTLE_API_KEY to a short-term Bedrock API key (valid 12h)
   # Generate: pip install aws-bedrock-token-generator && python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())"
-  #
-  # Note: GPT-5.4 and GPT-5.5 only support the Responses API (not Chat Completions) and
-  # are therefore not compatible with Codex or LiteLLM's chat proxy. Use GPT-OSS models below.
+  # Note: route_all_chat_openai_to_responses (below) transparently maps Chat Completions → Responses API
 
+  - model_name: gpt-5.4
+    litellm_params:
+      model: openai/openai.gpt-5.4
+      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+
+  - model_name: gpt-5.5
+    litellm_params:
+      model: openai/openai.gpt-5.5
+      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+      api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"  # us-east-2 only
+
+  # OpenAI GPT-OSS models via Amazon Bedrock Mantle (Chat Completions — native support)
   - model_name: gpt-4o
     litellm_params:
-      model: bedrock_mantle/openai.gpt-oss-safeguard-120b
+      model: openai/openai.gpt-oss-safeguard-120b
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
 
   - model_name: gpt-4o-mini
     litellm_params:
-      model: bedrock_mantle/openai.gpt-oss-safeguard-20b
+      model: openai/openai.gpt-oss-safeguard-20b
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
 
   - model_name: gpt-oss-120b
     litellm_params:
-      model: bedrock_mantle/openai.gpt-oss-120b
+      model: openai/openai.gpt-oss-120b
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
 
   - model_name: gpt-oss-20b
     litellm_params:
-      model: bedrock_mantle/openai.gpt-oss-20b
+      model: openai/openai.gpt-oss-20b
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY
@@ -47,5 +58,6 @@ general_settings:
 
 litellm_settings:
   set_verbose: false
-  drop_params: true               # silently drop unsupported OpenAI params
-  # callbacks: ["otel"]           # uncomment + set OTEL_ENDPOINT env var if you wire up an OTel collector
+  drop_params: true                          # silently drop unsupported OpenAI params
+  route_all_chat_openai_to_responses: true   # routes gpt-5.x chat/completions calls → Responses API
+  # callbacks: ["otel"]                      # uncomment + set OTEL_ENDPOINT env var if you wire up an OTel collector

--- a/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
+++ b/guidance-for-codex-on-amazon-bedrock/deployment/litellm/litellm_config.yaml
@@ -2,17 +2,17 @@ model_list:
   # OpenAI GPT-5.x models via Amazon Bedrock Mantle
   # Auth: set BEDROCK_MANTLE_API_KEY to a short-term Bedrock API key (valid 12h)
   # Generate: pip install aws-bedrock-token-generator && python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())"
-  # Note: route_all_chat_openai_to_responses below transparently maps Chat Completions → Responses API
+  # Note: Codex (v0.136+) calls /v1/responses directly (wire_api=responses). LiteLLM proxies to Bedrock Mantle as-is.
 
   - model_name: gpt-5.4
     litellm_params:
-      model: openai/responses/openai.gpt-5.4
+      model: openai/openai.gpt-5.4
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
       api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
   - model_name: gpt-5.5
     litellm_params:
-      model: openai/responses/openai.gpt-5.5
+      model: openai/openai.gpt-5.5
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
       api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 

--- a/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY.md
+++ b/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY.md
@@ -111,7 +111,7 @@ Once deployed, developers configure Codex to use the gateway. Your admin provide
 ```toml
 # ~/.codex/config.toml
 model_provider = "my-gateway"
-model = "gpt-4o"  # or openai.gpt-oss-120b
+model = "gpt-4o"  # maps to GPT-OSS Safeguard 120b via Bedrock Mantle
 
 [model_providers.my-gateway]
 name = "My LLM Gateway"

--- a/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY_LITELLM.md
+++ b/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY_LITELLM.md
@@ -136,9 +136,10 @@ export GATEWAY_STACK=codex-litellm-gateway
 export MASTER_KEY=$(openssl rand -hex 32)
 export DB_PASSWORD=$(openssl rand -base64 32)
 
-# Generate a short-term Bedrock Mantle API key (valid 12h) — required for GPT-5.x and GPT-OSS models
+# Generate a short-term Bedrock Mantle API key scoped to us-east-2 (valid 12h)
+# Both gpt-5.4 and gpt-5.5 use us-east-2 endpoints — key must match
 pip install aws-bedrock-token-generator -q
-export BEDROCK_MANTLE_KEY=$(python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())")
+export BEDROCK_MANTLE_KEY=$(AWS_DEFAULT_REGION=us-east-2 python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())")
 
 # Deploy gateway (references networking stack via imports)
 aws cloudformation deploy \
@@ -429,28 +430,16 @@ model_list:
     litellm_params:
       model: openai/openai.gpt-5.4
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+      api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
   - model_name: gpt-5.5
     litellm_params:
       model: openai/openai.gpt-5.5
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
       api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
-
-  - model_name: gpt-4o
-    litellm_params:
-      model: openai/openai.gpt-oss-safeguard-120b
-      api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
-
-  - model_name: gpt-4o-mini
-    litellm_params:
-      model: openai/openai.gpt-oss-safeguard-20b
-      api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
 ```
 
-> **Note on GPT-5.4 / GPT-5.5:** These models use the Responses API. The `route_all_chat_openai_to_responses: true` setting in `litellm_settings` transparently maps incoming Chat Completions requests to the Responses API, so Codex works without any client-side changes.
+> **Note on GPT-5.4 / GPT-5.5:** These models use the Responses API. The `route_all_chat_openai_to_responses: true` setting in `litellm_settings` transparently maps incoming Chat Completions requests to the Responses API, so Codex works without any client-side changes. Both endpoints use `us-east-2` so a single `BEDROCK_MANTLE_API_KEY` (generated with `AWS_DEFAULT_REGION=us-east-2`) covers both models. GPT-5.4 is also available in `us-west-2` — see `reference-regions.md` if you prefer a different region.
 
 Rebuild and redeploy the image (Steps 2 & 6).
 

--- a/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY_LITELLM.md
+++ b/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY_LITELLM.md
@@ -136,6 +136,10 @@ export GATEWAY_STACK=codex-litellm-gateway
 export MASTER_KEY=$(openssl rand -hex 32)
 export DB_PASSWORD=$(openssl rand -base64 32)
 
+# Generate a short-term Bedrock Mantle API key (valid 12h) — required for GPT-5.x and GPT-OSS models
+pip install aws-bedrock-token-generator -q
+export BEDROCK_MANTLE_KEY=$(python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())")
+
 # Deploy gateway (references networking stack via imports)
 aws cloudformation deploy \
   --stack-name "$GATEWAY_STACK" \
@@ -147,6 +151,7 @@ aws cloudformation deploy \
       OtelStackName="$OTEL_STACK" \
       EnableOtel="true" \
       LiteLLMMasterKey="$MASTER_KEY" \
+      BedrockMantleApiKey="$BEDROCK_MANTLE_KEY" \
       DBPassword="$DB_PASSWORD" \
       AwsRegion="$AWS_REGION" \
       LiteLLMImage="$LITELLM_IMAGE" \
@@ -182,7 +187,7 @@ curl -X POST "$GATEWAY_URL/key/generate" \
   -d '{
     "key_alias": "alice@company.com",
     "user_id": "alice@company.com",
-    "models": ["openai.gpt-oss-120b"],
+    "models": ["gpt-4o", "gpt-4o-mini", "gpt-oss-120b"],
     "max_budget": 50.0,
     "budget_duration": "30d",
     "tpm_limit": 100000,
@@ -202,7 +207,7 @@ Developers add this to `~/.codex/config.toml`:
 
 ```toml
 model_provider = "litellm-gateway"
-model = "gpt-4o"
+model = "gpt-4o"  # maps to GPT-OSS Safeguard 120b via Bedrock Mantle
 
 [model_providers.litellm-gateway]
 name = "LiteLLM Gateway"
@@ -347,7 +352,7 @@ echo $OPENAI_API_KEY
 curl -X POST "$GATEWAY_URL/v1/chat/completions" \
   -H "Authorization: Bearer $OPENAI_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"model":"gpt-4o","messages":[{"role":"user","content":"test"}]}'
+  -d '{"model":"gpt-5.4","messages":[{"role":"user","content":"test"}]}'
 ```
 
 ### Docker build fails
@@ -422,14 +427,18 @@ Edit `deployment/litellm/litellm_config.yaml`:
 model_list:
   - model_name: gpt-4o
     litellm_params:
-      model: bedrock/openai.gpt-oss-120b
-      aws_region_name: us-west-2
-  
+      model: bedrock_mantle/openai.gpt-oss-safeguard-120b
+      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
+
   - model_name: gpt-4o-mini
     litellm_params:
-      model: bedrock/openai.gpt-oss-20b
-      aws_region_name: us-west-2
+      model: bedrock_mantle/openai.gpt-oss-safeguard-20b
+      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
 ```
+
+> **Note on GPT-5.4 / GPT-5.5:** These models only support the OpenAI Responses API, not Chat Completions. They are not compatible with Codex or LiteLLM's chat proxy. Use GPT-OSS models above for Codex workloads.
 
 Rebuild and redeploy the image (Steps 2 & 6).
 

--- a/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY_LITELLM.md
+++ b/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY_LITELLM.md
@@ -208,14 +208,17 @@ Developers add this to `~/.codex/config.toml`:
 
 ```toml
 model_provider = "litellm-gateway"
-model = "gpt-4o"  # maps to GPT-OSS Safeguard 120b via Bedrock Mantle
+model = "gpt-5.5"
+web_search = "disabled"   # Bedrock Mantle does not support the web_search tool type
 
 [model_providers.litellm-gateway]
 name = "LiteLLM Gateway"
 base_url = "http://<gateway-url>/v1"
 env_key = "OPENAI_API_KEY"
-wire_api = "chat"
+wire_api = "responses"    # Codex 0.136+ calls /v1/responses directly; must match
 ```
+
+> **Note:** `wire_api = "responses"` is required for GPT-5.x because these models only support the Responses API. `web_search = "disabled"` prevents Codex from sending a tool type that Bedrock Mantle does not accept. Both settings are required for requests to succeed.
 
 Set API key:
 
@@ -428,18 +431,18 @@ Edit `deployment/litellm/litellm_config.yaml`:
 model_list:
   - model_name: gpt-5.4
     litellm_params:
-      model: openai/responses/openai.gpt-5.4
+      model: openai/openai.gpt-5.4
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
       api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
   - model_name: gpt-5.5
     litellm_params:
-      model: openai/responses/openai.gpt-5.5
+      model: openai/openai.gpt-5.5
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
       api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 ```
 
-> **Note on GPT-5.4 / GPT-5.5:** These models only support the Responses API. The `responses/` prefix in the model string tells LiteLLM to route the request through its Responses API bridge, transparently converting incoming Chat Completions requests so Codex works without client-side changes. Both endpoints use `us-east-2` so a single `BEDROCK_MANTLE_API_KEY` (generated with `AWS_DEFAULT_REGION=us-east-2`) covers both models. GPT-5.4 is also available in `us-west-2` — see `reference-regions.md` if you prefer a different region.
+> **Note on GPT-5.4 / GPT-5.5:** These models only support the Responses API. The `openai/` prefix tells LiteLLM to proxy the request to the OpenAI-compatible Bedrock Mantle endpoint as-is — no additional routing needed because Codex (v0.136+) already calls `/v1/responses` directly via `wire_api = "responses"`. Both endpoints use `us-east-2` so a single `BEDROCK_MANTLE_API_KEY` (generated with `AWS_DEFAULT_REGION=us-east-2`) covers both models. GPT-5.4 is also available in `us-west-2` — see `reference-regions.md` if you prefer a different region.
 
 Rebuild and redeploy the image (Steps 2 & 6).
 

--- a/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY_LITELLM.md
+++ b/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY_LITELLM.md
@@ -425,20 +425,32 @@ Edit `deployment/litellm/litellm_config.yaml`:
 
 ```yaml
 model_list:
+  - model_name: gpt-5.4
+    litellm_params:
+      model: openai/openai.gpt-5.4
+      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+
+  - model_name: gpt-5.5
+    litellm_params:
+      model: openai/openai.gpt-5.5
+      api_key: os.environ/BEDROCK_MANTLE_API_KEY
+      api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
+
   - model_name: gpt-4o
     litellm_params:
-      model: bedrock_mantle/openai.gpt-oss-safeguard-120b
+      model: openai/openai.gpt-oss-safeguard-120b
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
 
   - model_name: gpt-4o-mini
     litellm_params:
-      model: bedrock_mantle/openai.gpt-oss-safeguard-20b
+      model: openai/openai.gpt-oss-safeguard-20b
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
-      api_base: "https://bedrock-mantle.us-west-2.api.aws/v1"
+      api_base: "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
 ```
 
-> **Note on GPT-5.4 / GPT-5.5:** These models only support the OpenAI Responses API, not Chat Completions. They are not compatible with Codex or LiteLLM's chat proxy. Use GPT-OSS models above for Codex workloads.
+> **Note on GPT-5.4 / GPT-5.5:** These models use the Responses API. The `route_all_chat_openai_to_responses: true` setting in `litellm_settings` transparently maps incoming Chat Completions requests to the Responses API, so Codex works without any client-side changes.
 
 Rebuild and redeploy the image (Steps 2 & 6).
 

--- a/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY_LITELLM.md
+++ b/guidance-for-codex-on-amazon-bedrock/docs/QUICKSTART_LLM_GATEWAY_LITELLM.md
@@ -428,18 +428,18 @@ Edit `deployment/litellm/litellm_config.yaml`:
 model_list:
   - model_name: gpt-5.4
     litellm_params:
-      model: openai/openai.gpt-5.4
+      model: openai/responses/openai.gpt-5.4
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
       api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
   - model_name: gpt-5.5
     litellm_params:
-      model: openai/openai.gpt-5.5
+      model: openai/responses/openai.gpt-5.5
       api_key: os.environ/BEDROCK_MANTLE_API_KEY
       api_base: "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 ```
 
-> **Note on GPT-5.4 / GPT-5.5:** These models use the Responses API. The `route_all_chat_openai_to_responses: true` setting in `litellm_settings` transparently maps incoming Chat Completions requests to the Responses API, so Codex works without any client-side changes. Both endpoints use `us-east-2` so a single `BEDROCK_MANTLE_API_KEY` (generated with `AWS_DEFAULT_REGION=us-east-2`) covers both models. GPT-5.4 is also available in `us-west-2` — see `reference-regions.md` if you prefer a different region.
+> **Note on GPT-5.4 / GPT-5.5:** These models only support the Responses API. The `responses/` prefix in the model string tells LiteLLM to route the request through its Responses API bridge, transparently converting incoming Chat Completions requests so Codex works without client-side changes. Both endpoints use `us-east-2` so a single `BEDROCK_MANTLE_API_KEY` (generated with `AWS_DEFAULT_REGION=us-east-2`) covers both models. GPT-5.4 is also available in `us-west-2` — see `reference-regions.md` if you prefer a different region.
 
 Rebuild and redeploy the image (Steps 2 & 6).
 

--- a/guidance-for-codex-on-amazon-bedrock/docs/reference-regions.md
+++ b/guidance-for-codex-on-amazon-bedrock/docs/reference-regions.md
@@ -19,8 +19,8 @@ in any region as access expands.
 
 | Model ID | Endpoint | Regions | API | Notes |
 |---|---|---|---|---|
-| `openai.gpt-5.5` | Mantle | `us-east-2` | Responses only | Routed via LiteLLM `responses/` model prefix — transparent to Codex. |
-| `openai.gpt-5.4` | Mantle | `us-east-2`, `us-west-2`, `us-gov-west-1` | Responses only | **Recommended default.** Routed via LiteLLM `responses/` model prefix — transparent to Codex. |
+| `openai.gpt-5.5` | Mantle | `us-east-2` | Responses only | Codex uses `wire_api = "responses"` to call `/v1/responses` directly; LiteLLM proxies straight to Bedrock Mantle. |
+| `openai.gpt-5.4` | Mantle | `us-east-2`, `us-west-2`, `us-gov-west-1` | Responses only | **Recommended default.** Codex uses `wire_api = "responses"` to call `/v1/responses` directly; LiteLLM proxies straight to Bedrock Mantle. |
 | `openai.gpt-oss-safeguard-120b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions | Maps to `gpt-4o` alias in gateway. |
 | `openai.gpt-oss-safeguard-20b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions | Maps to `gpt-4o-mini` alias in gateway. |
 | `openai.gpt-oss-120b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions + Responses | Full API support. |
@@ -30,7 +30,7 @@ The LiteLLM gateway config uses `us-east-2` for both models (single Bedrock API 
 
 ## Endpoints
 
-- **Mantle (OpenAI-compatible API):** `bedrock-mantle.<region>.api.aws/openai/v1` — serves GPT-5.4, GPT-5.5, and GPT-OSS models. Used by the LiteLLM Gateway via the `openai/responses/<model>` model string, which routes Chat Completions requests through LiteLLM's Responses API bridge transparently.
+- **Mantle (OpenAI-compatible API):** `bedrock-mantle.<region>.api.aws/openai/v1` — serves GPT-5.4, GPT-5.5, and GPT-OSS models. The LiteLLM Gateway uses the `openai/<model>` model string and proxies requests from Codex (which calls `/v1/responses` directly via `wire_api = "responses"`) straight to Bedrock Mantle.
 
 > **Note:** The LiteLLM gateway config uses `us-east-2` for both GPT-5.4 and GPT-5.5 because the Bedrock API key must be scoped to a single region. GPT-5.4 is also available in `us-west-2` and `us-gov-west-1` — override the `api_base` and set `AWS_DEFAULT_REGION=<region>` when generating the key if you need a different region.
 

--- a/guidance-for-codex-on-amazon-bedrock/docs/reference-regions.md
+++ b/guidance-for-codex-on-amazon-bedrock/docs/reference-regions.md
@@ -26,11 +26,13 @@ in any region as access expands.
 | `openai.gpt-oss-120b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions + Responses | Full API support. |
 | `openai.gpt-oss-20b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions + Responses | Full API support. |
 
-CLI examples in this repository use `us-west-2` as a placeholder. For GPT-5.5, use `us-east-2`. For GPT-5.4, substitute any supported region.
+The LiteLLM gateway config uses `us-east-2` for both models (single Bedrock API key scope). For GPT-5.4 in `us-west-2` or `us-gov-west-1`, update `api_base` in `litellm_config.yaml` and regenerate the key with `AWS_DEFAULT_REGION=<region>`.
 
 ## Endpoints
 
 - **Mantle (OpenAI-compatible API):** `bedrock-mantle.<region>.api.aws/openai/v1` — serves GPT-5.4, GPT-5.5, and GPT-OSS models. Used by the LiteLLM Gateway via the `openai/` provider prefix with `route_all_chat_openai_to_responses: true` for GPT-5.x.
+
+> **Note:** The LiteLLM gateway config uses `us-east-2` for both GPT-5.4 and GPT-5.5 because the Bedrock API key must be scoped to a single region. GPT-5.4 is also available in `us-west-2` and `us-gov-west-1` — override the `api_base` and set `AWS_DEFAULT_REGION=<region>` when generating the key if you need a different region.
 
 Authenticates with a Bedrock API key as a Bearer token (`Authorization: Bearer <key>`). Generate a short-term key (12h) from your IAM credentials:
 ```bash

--- a/guidance-for-codex-on-amazon-bedrock/docs/reference-regions.md
+++ b/guidance-for-codex-on-amazon-bedrock/docs/reference-regions.md
@@ -17,18 +17,26 @@ getting-started guide — if that guide disagrees, it takes precedence.
 Run `aws bedrock list-foundation-models --region <region>` to check availability
 in any region as access expands.
 
-| Model ID | Endpoint | Regions | Notes |
-|---|---|---|---|
-| `openai.gpt-5.5` | Mantle | `us-east-2` | Latest model. Reasoning + verbosity params supported. |
-| `openai.gpt-5.4` | Mantle | `us-east-2`, `us-west-2` | **Recommended default.** Broader region coverage. |
+| Model ID | Endpoint | Regions | API | Notes |
+|---|---|---|---|---|
+| `openai.gpt-5.5` | Mantle | `us-east-2` | Responses only | Responses API only — not compatible with Codex or Chat Completions clients. |
+| `openai.gpt-5.4` | Mantle | `us-east-2`, `us-west-2`, `us-gov-west-1` | Responses only | Responses API only — not compatible with Codex or Chat Completions clients. |
+| `openai.gpt-oss-safeguard-120b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions | **Recommended for Codex.** Maps to `gpt-4o` alias in gateway. |
+| `openai.gpt-oss-safeguard-20b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions | Maps to `gpt-4o-mini` alias in gateway. |
+| `openai.gpt-oss-120b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions + Responses | Full API support. |
+| `openai.gpt-oss-20b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions + Responses | Full API support. |
 
 CLI examples in this repository use `us-west-2` as a placeholder. For GPT-5.5, use `us-east-2`. For GPT-5.4, substitute any supported region.
 
 ## Endpoints
 
-- **Mantle (OpenAI-compatible Responses API):** `bedrock-mantle.<region>.api.aws/openai/v1` — serves GPT-5.4 and GPT-5.5. This is the endpoint the Codex `amazon-bedrock` provider and the LiteLLM Gateway `openai` → Bedrock route target.
+- **Mantle (OpenAI-compatible API):** `bedrock-mantle.<region>.api.aws/v1` — serves GPT-5.4, GPT-5.5, and GPT-OSS models. Used by the LiteLLM Gateway via the `bedrock_mantle/` provider prefix.
 
-Accepts SigV4 with service name `bedrock-mantle` (e.g. `--aws-sigv4 "aws:amz:us-east-2:bedrock-mantle"`).
+Authenticates with a Bedrock API key as a Bearer token (`Authorization: Bearer <key>`). Generate a short-term key (12h) from your IAM credentials:
+```bash
+pip install aws-bedrock-token-generator
+python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())"
+```
 
 ## Quotas
 

--- a/guidance-for-codex-on-amazon-bedrock/docs/reference-regions.md
+++ b/guidance-for-codex-on-amazon-bedrock/docs/reference-regions.md
@@ -19,8 +19,8 @@ in any region as access expands.
 
 | Model ID | Endpoint | Regions | API | Notes |
 |---|---|---|---|---|
-| `openai.gpt-5.5` | Mantle | `us-east-2` | Responses only | Compatible with Codex via LiteLLM `route_all_chat_openai_to_responses`. |
-| `openai.gpt-5.4` | Mantle | `us-east-2`, `us-west-2`, `us-gov-west-1` | Responses only | **Recommended default.** Compatible with Codex via LiteLLM `route_all_chat_openai_to_responses`. |
+| `openai.gpt-5.5` | Mantle | `us-east-2` | Responses only | Routed via LiteLLM `responses/` model prefix — transparent to Codex. |
+| `openai.gpt-5.4` | Mantle | `us-east-2`, `us-west-2`, `us-gov-west-1` | Responses only | **Recommended default.** Routed via LiteLLM `responses/` model prefix — transparent to Codex. |
 | `openai.gpt-oss-safeguard-120b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions | Maps to `gpt-4o` alias in gateway. |
 | `openai.gpt-oss-safeguard-20b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions | Maps to `gpt-4o-mini` alias in gateway. |
 | `openai.gpt-oss-120b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions + Responses | Full API support. |
@@ -30,7 +30,7 @@ The LiteLLM gateway config uses `us-east-2` for both models (single Bedrock API 
 
 ## Endpoints
 
-- **Mantle (OpenAI-compatible API):** `bedrock-mantle.<region>.api.aws/openai/v1` — serves GPT-5.4, GPT-5.5, and GPT-OSS models. Used by the LiteLLM Gateway via the `openai/` provider prefix with `route_all_chat_openai_to_responses: true` for GPT-5.x.
+- **Mantle (OpenAI-compatible API):** `bedrock-mantle.<region>.api.aws/openai/v1` — serves GPT-5.4, GPT-5.5, and GPT-OSS models. Used by the LiteLLM Gateway via the `openai/responses/<model>` model string, which routes Chat Completions requests through LiteLLM's Responses API bridge transparently.
 
 > **Note:** The LiteLLM gateway config uses `us-east-2` for both GPT-5.4 and GPT-5.5 because the Bedrock API key must be scoped to a single region. GPT-5.4 is also available in `us-west-2` and `us-gov-west-1` — override the `api_base` and set `AWS_DEFAULT_REGION=<region>` when generating the key if you need a different region.
 

--- a/guidance-for-codex-on-amazon-bedrock/docs/reference-regions.md
+++ b/guidance-for-codex-on-amazon-bedrock/docs/reference-regions.md
@@ -19,9 +19,9 @@ in any region as access expands.
 
 | Model ID | Endpoint | Regions | API | Notes |
 |---|---|---|---|---|
-| `openai.gpt-5.5` | Mantle | `us-east-2` | Responses only | Responses API only — not compatible with Codex or Chat Completions clients. |
-| `openai.gpt-5.4` | Mantle | `us-east-2`, `us-west-2`, `us-gov-west-1` | Responses only | Responses API only — not compatible with Codex or Chat Completions clients. |
-| `openai.gpt-oss-safeguard-120b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions | **Recommended for Codex.** Maps to `gpt-4o` alias in gateway. |
+| `openai.gpt-5.5` | Mantle | `us-east-2` | Responses only | Compatible with Codex via LiteLLM `route_all_chat_openai_to_responses`. |
+| `openai.gpt-5.4` | Mantle | `us-east-2`, `us-west-2`, `us-gov-west-1` | Responses only | **Recommended default.** Compatible with Codex via LiteLLM `route_all_chat_openai_to_responses`. |
+| `openai.gpt-oss-safeguard-120b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions | Maps to `gpt-4o` alias in gateway. |
 | `openai.gpt-oss-safeguard-20b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions | Maps to `gpt-4o-mini` alias in gateway. |
 | `openai.gpt-oss-120b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions + Responses | Full API support. |
 | `openai.gpt-oss-20b` | Mantle | `us-east-2`, `us-west-2`, `us-east-1` | Chat Completions + Responses | Full API support. |
@@ -30,7 +30,7 @@ CLI examples in this repository use `us-west-2` as a placeholder. For GPT-5.5, u
 
 ## Endpoints
 
-- **Mantle (OpenAI-compatible API):** `bedrock-mantle.<region>.api.aws/v1` — serves GPT-5.4, GPT-5.5, and GPT-OSS models. Used by the LiteLLM Gateway via the `bedrock_mantle/` provider prefix.
+- **Mantle (OpenAI-compatible API):** `bedrock-mantle.<region>.api.aws/openai/v1` — serves GPT-5.4, GPT-5.5, and GPT-OSS models. Used by the LiteLLM Gateway via the `openai/` provider prefix with `route_all_chat_openai_to_responses: true` for GPT-5.x.
 
 Authenticates with a Bedrock API key as a Bearer token (`Authorization: Bearer <key>`). Generate a short-term key (12h) from your IAM credentials:
 ```bash


### PR DESCRIPTION
## Summary

- Fixes `litellm_config.yaml` which incorrectly used `bedrock/openai.gpt-5.x` — those models only support the Responses API, not Chat Completions, so they cannot work with Codex or LiteLLM's chat proxy
- Switches all models to the `bedrock_mantle/` provider prefix with `BEDROCK_MANTLE_API_KEY` auth (Bearer token generated from IAM credentials)
- Wires `BEDROCK_MANTLE_API_KEY` through Secrets Manager into the ECS task, with `bedrock:CallWithBearerToken` IAM permission
- Updates docs and reference matrix to clearly show which models support Chat Completions vs Responses API only

## What was verified

All four GPT-OSS models confirmed working via `bedrock-mantle.us-west-2.api.aws/v1/chat/completions` with short-term Bedrock API key:
- `openai.gpt-oss-safeguard-120b` → HTTP 200
- `openai.gpt-oss-safeguard-20b` → HTTP 200
- `openai.gpt-oss-120b` → HTTP 200
- `openai.gpt-oss-20b` → HTTP 200

GPT-5.4 and GPT-5.5 return HTTP 400 on Chat Completions — confirmed Responses API only per [AWS API compatibility docs](https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html).

## Test plan

- [ ] Generate a Bedrock Mantle API key: `pip install aws-bedrock-token-generator && python -c "from aws_bedrock_token_generator import provide_token; print(provide_token())"`
- [ ] Deploy gateway with new `BedrockMantleApiKey` parameter
- [ ] Confirm `curl -H "Authorization: Bearer $LITELLM_KEY" $GATEWAY_URL/v1/chat/completions -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}'` returns 200